### PR TITLE
Add CharStrategy::new_borrowed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *~
 target
 Cargo.lock
+
+# VSCode:
+.vscode/


### PR DESCRIPTION
Adds:
+ `char::CharStrategy::new_borrowed`.

Makes it a bit more ergonomic to construct a `CharStrategy` in the more usual case (not `Owned`).