### PR TITLE
Type aliases:  ValueFor<S> and W<T> + subsequence + other stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 
 - `TestRunner` now implements `Default`.
 
+- Added `Config::with_cases(number_of_cases: u32) -> Config` for simpler
+  construction of a `Config` that only differs by the number of test cases.
+
+- The default number of test cases to run is `256` (as before). This default
+  which is encoded by `Config::default()` is now configurable by setting the
+  env-var `PROPTEST_REQUIRED_CASES` to a value that can be parsed as a `u32`.
+  This variable is read at runtime.
+
+- bumped dependency `rand = "0.3.18"`.
+
 ## 0.3.1
 
 ### New Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
 
 - bumped dependency `rand = "0.3.18"`.
 
+- Added `proptest::collection::subsequence<T: Clone>(Vec<T>, Range<usize>)`
+  which returns a strategy generating subsequences, of the source `Vec`,
+  with a size within the given `Range`.
+
+- Added the trait `CollectionStrategy` which provides `.prop_sample` directly
+  on collection types. The operation is the same as `subsequence` for `Vec`.
+
 ## 0.3.1
 
 ### New Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.3.2
+
+### New Additions
+
+- Added a type alias `ValueFor<S>` where `S: Strategy`. This is a shorter way
+  to refer to: `<<S as Strategy>::Value as ValueTree>::Value`.
+
+- Added a type alias `type W<T> = (u32, T)` for a weighted strategy `T` in the
+  context of union strategies.
+
 ## 0.3.1
 
 ### New Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Added a type alias `type W<T> = (u32, T)` for a weighted strategy `T` in the
   context of union strategies.
 
+- `TestRunner` now implements `Default`.
+
 ## 0.3.1
 
 ### New Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ Hypothesis-like property-based testing and shrinking.
 [dependencies]
 bit-set = "0.4.0"
 quick-error = "1.2.1"
-rand = "0.3.15"
+rand = "0.3.18"
 regex-syntax = "0.4.1"
+lazy_static = "0.2.8"
 
 [dev-dependencies]
 regex = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proptest"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jason Lingle"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/examples/dateparser_v1.rs
+++ b/examples/dateparser_v1.rs
@@ -36,7 +36,7 @@ fn main() {
     assert_eq!(None, parse_date("2017-06-170"));
     assert_eq!(None, parse_date("2017006-17"));
     assert_eq!(None, parse_date("2017-06017"));
-    assert_eq!(Some((2017, 06, 17)), parse_date("2017-06-17"));
+    assert_eq!(Some((2017, 6, 17)), parse_date("2017-06-17"));
 
     doesnt_crash();
 }

--- a/examples/dateparser_v2.rs
+++ b/examples/dateparser_v2.rs
@@ -39,7 +39,7 @@ proptest! {
         parse_date(s).unwrap();
     }
 
-    fn parses_date_back_to_original(y in 0u32..10000,
+    fn parses_date_back_to_original(y in 0u32..10_000,
                                     m in 1u32..13, d in 1u32..32) {
         let (y2, m2, d2) = parse_date(
             &format!("{:04}-{:02}-{:02}", y, m, d)).unwrap();
@@ -52,7 +52,7 @@ fn main() {
     assert_eq!(None, parse_date("2017-06-170"));
     assert_eq!(None, parse_date("2017006-17"));
     assert_eq!(None, parse_date("2017-06017"));
-    assert_eq!(Some((2017, 06, 17)), parse_date("2017-06-17"));
+    assert_eq!(Some((2017, 6, 17)), parse_date("2017-06-17"));
 
     doesnt_crash();
     parses_all_valid_dates();

--- a/examples/dateparser_v2.rs
+++ b/examples/dateparser_v2.rs
@@ -9,8 +9,6 @@
 
 #[macro_use] extern crate proptest;
 
-use std::ascii::AsciiExt;
-
 fn parse_date(s: &str) -> Option<(u32, u32, u32)> {
     if 10 != s.len() { return None; }
 

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -26,6 +26,7 @@ use strategy::*;
 use test_runner::*;
 
 /// Trait for types which can be handled with `BitSetStrategy`.
+#[cfg_attr(feature="cargo-clippy", allow(len_without_is_empty))]
 pub trait BitSetLike : Clone + fmt::Debug {
     /// Create a new value of `Self` with space for up to `max` bits, all
     /// initialised to zero.

--- a/src/char.rs
+++ b/src/char.rs
@@ -117,7 +117,7 @@ fn select_range_index<R : Rng>(rnd: &mut R,
         }
     }
 
-    for _ in 0..65536 {
+    for _ in 0..65_536 {
         let (lo, hi) = ranges[rnd.gen_range(0, ranges.len())];
         if let Some(ch) = ::std::char::from_u32(
             rnd.gen_range(lo as u32, hi as u32 + 1))

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -32,7 +32,7 @@ use test_runner::*;
 // TODO: tests for CollectionStrategy impls.
 
 /// Returns a `Strategy` that generates subsequences of `source` where the
-/// where the subsequences have a number of elements `len`. Given a range
+/// subsequences have a number of elements `len`. Given a range
 /// `size = min..max` then `min <= len < max`.
 ///
 /// # Safety

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -16,7 +16,6 @@ use std::collections::*;
 use std::fmt;
 use std::hash::Hash;
 use std::ops::Range;
-use std::slice;
 
 use bit_set::BitSet;
 use rand;
@@ -156,9 +155,7 @@ impl<T: Clone + fmt::Debug> ValueTree for SubseqValueTree<T> {
         // We verify manually that self.len <= self.data.len(),
         // therefore it is safe. The assertion should always hold.
         assert!(self.len <= self.data.len());
-        unsafe {
-            slice::from_raw_parts(self.data.as_ptr(), self.len)
-        }.into()
+        self.data[..self.len].into()
     }
 
     fn simplify(&mut self) -> bool {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -113,8 +113,7 @@ opaque_strategy_wrapper! {
     ///
     /// Created by the `binary_heap()` function in the same module.
     #[derive(Clone, Debug)]
-    pub struct BinaryHeapStrategy[<T>][where T : Strategy,
-                                       <T::Value as ValueTree>::Value : Ord](
+    pub struct BinaryHeapStrategy[<T>][where T : Strategy, ValueFor<T> : Ord](
         statics::Map<VecStrategy<T>, VecToBinHeap>)
         -> BinaryHeapValueTree<T::Value>;
     /// `ValueTree` corresponding to `BinaryHeapStrategy`.
@@ -129,7 +128,7 @@ opaque_strategy_wrapper! {
 pub fn binary_heap<T : Strategy>
     (element: T, size: Range<usize>)
     -> BinaryHeapStrategy<T>
-where <T::Value as ValueTree>::Value : Ord {
+where ValueFor<T> : Ord {
     BinaryHeapStrategy(statics::Map::new(vec(element, size), VecToBinHeap))
 }
 
@@ -154,8 +153,7 @@ opaque_strategy_wrapper! {
     ///
     /// Created by the `hash_set()` function in the same module.
     #[derive(Clone, Debug)]
-    pub struct HashSetStrategy[<T>][where T : Strategy,
-                                    <T::Value as ValueTree>::Value : Hash + Eq](
+    pub struct HashSetStrategy[<T>][where T : Strategy, ValueFor<T> : Hash + Eq](
         statics::Filter<statics::Map<VecStrategy<T>, VecToHashSet>, MinSize>)
         -> HashSetValueTree<T::Value>;
     /// `ValueTree` corresponding to `HashSetStrategy`.
@@ -174,7 +172,7 @@ opaque_strategy_wrapper! {
 pub fn hash_set<T : Strategy>
     (element: T, size: Range<usize>)
     -> HashSetStrategy<T>
-where <T::Value as ValueTree>::Value : Hash + Eq {
+where ValueFor<T> : Hash + Eq {
     let min_size = size.start;
     HashSetStrategy(statics::Filter::new(
         statics::Map::new(vec(element, size), VecToHashSet),
@@ -200,8 +198,7 @@ opaque_strategy_wrapper! {
     ///
     /// Created by the `btree_set()` function in the same module.
     #[derive(Clone, Debug)]
-    pub struct BTreeSetStrategy[<T>][where T : Strategy,
-                                     <T::Value as ValueTree>::Value : Ord](
+    pub struct BTreeSetStrategy[<T>][where T : Strategy, ValueFor<T> : Ord](
         statics::Filter<statics::Map<VecStrategy<T>, VecToBTreeSet>, MinSize>)
         -> BTreeSetValueTree<T::Value>;
     /// `ValueTree` corresponding to `BTreeSetStrategy`.
@@ -220,7 +217,7 @@ opaque_strategy_wrapper! {
 pub fn btree_set<T : Strategy>
     (element: T, size: Range<usize>)
     -> BTreeSetStrategy<T>
-where <T::Value as ValueTree>::Value : Ord {
+where ValueFor<T> : Ord {
     let min_size = size.start;
 
     BTreeSetStrategy(statics::Filter::new(
@@ -249,8 +246,7 @@ opaque_strategy_wrapper! {
     /// Created by the `hash_map()` function in the same module.
     #[derive(Clone, Debug)]
     pub struct HashMapStrategy[<K, V>]
-        [where K : Strategy, V : Strategy,
-         <K::Value as ValueTree>::Value : Hash + Eq](
+        [where K : Strategy, V : Strategy, ValueFor<K> : Hash + Eq](
             statics::Filter<statics::Map<VecStrategy<(K,V)>,
             VecToHashMap>, MinSize>)
         -> HashMapValueTree<K::Value, V::Value>;
@@ -273,7 +269,7 @@ opaque_strategy_wrapper! {
 pub fn hash_map<K : Strategy, V : Strategy>
     (key: K, value: V, size: Range<usize>)
     -> HashMapStrategy<K, V>
-where <K::Value as ValueTree>::Value : Hash + Eq {
+where ValueFor<K> : Hash + Eq {
     let min_size = size.start;
     HashMapStrategy(statics::Filter::new(
         statics::Map::new(vec((key, value), size), VecToHashMap),
@@ -301,8 +297,7 @@ opaque_strategy_wrapper! {
     /// Created by the `btree_map()` function in the same module.
     #[derive(Clone, Debug)]
     pub struct BTreeMapStrategy[<K, V>]
-        [where K : Strategy, V : Strategy,
-         <K::Value as ValueTree>::Value : Ord](
+        [where K : Strategy, V : Strategy, ValueFor<K> : Ord](
             statics::Filter<statics::Map<VecStrategy<(K,V)>,
             VecToBTreeMap>, MinSize>)
         -> BTreeMapValueTree<K::Value, V::Value>;
@@ -325,7 +320,7 @@ opaque_strategy_wrapper! {
 pub fn btree_map<K : Strategy + 'static, V : Strategy + 'static>
     (key: K, value: V, size: Range<usize>)
     -> BTreeMapStrategy<K, V>
-where <K::Value as ValueTree>::Value : Ord {
+where ValueFor<K> : Ord {
     let min_size = size.start;
     BTreeMapStrategy(statics::Filter::new(
         statics::Map::new(vec((key, value), size.clone()), VecToBTreeMap),

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -9,6 +9,8 @@
 
 //! Strategies for generating `std::collections` of values.
 
+#![cfg_attr(feature="cargo-clippy", allow(type_complexity))]
+
 use std::cmp::Ord;
 use std::collections::*;
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg_attr(feature="cargo-clippy", allow(doc_markdown))]
+
 //! Proptest is a property testing framework (i.e., the QuickCheck family)
 //! inspired by the [Hypothesis](http://hypothesis.works/) framework for
 //! Python. It allows to test that certain properties of your code hold for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,11 +417,11 @@
 //! ```rust
 //! extern crate proptest;
 //!
-//! use proptest::test_runner::{Config, TestRunner};
+//! use proptest::test_runner::TestRunner;
 //! use proptest::strategy::{Strategy, ValueTree};
 //!
 //! fn main() {
-//!     let mut runner = TestRunner::new(Config::default());
+//!     let mut runner = TestRunner::default();
 //!     let int_val = (0..100i32).new_value(&mut runner).unwrap();
 //!     let str_val = "[a-z]{1,4}\\p{Cyrillic}{1,4}\\p{Greek}{1,4}"
 //!         .new_value(&mut runner).unwrap();
@@ -446,7 +446,7 @@
 //! ```rust,no_run
 //! extern crate proptest;
 //!
-//! use proptest::test_runner::{Config, TestRunner};
+//! use proptest::test_runner::TestRunner;
 //! use proptest::strategy::{Strategy, ValueTree};
 //!
 //! fn some_function(v: i32) {
@@ -458,7 +458,7 @@
 //! #[test]
 //! # */
 //! fn some_function_doesnt_crash() {
-//!     let mut runner = TestRunner::new(Config::default());
+//!     let mut runner = TestRunner::default();
 //!     for _ in 0..256 {
 //!         let val = (0..10000i32).new_value(&mut runner).unwrap();
 //!         some_function(val.current());
@@ -487,11 +487,11 @@
 //! ```rust
 //! extern crate proptest;
 //!
-//! use proptest::test_runner::{Config, TestRunner};
+//! use proptest::test_runner::TestRunner;
 //! use proptest::strategy::{Strategy, ValueTree};
 //!
 //! fn main() {
-//!     let mut runner = TestRunner::new(Config::default());
+//!     let mut runner = TestRunner::default();
 //!     let mut str_val = "[a-z]{1,4}\\p{Cyrillic}{1,4}\\p{Greek}{1,4}"
 //!         .new_value(&mut runner).unwrap();
 //!     println!("str_val = {}", str_val.current());
@@ -568,7 +568,7 @@
 //! ```rust
 //! extern crate proptest;
 //!
-//! use proptest::test_runner::{Config, TestRunner};
+//! use proptest::test_runner::TestRunner;
 //! use proptest::strategy::{Strategy, ValueTree};
 //!
 //! fn some_function(v: i32) -> bool {
@@ -581,7 +581,7 @@
 //! // We know the function is broken, so use a purpose-built main function to
 //! // find the breaking point.
 //! fn main() {
-//!     let mut runner = TestRunner::new(Config::default());
+//!     let mut runner = TestRunner::default();
 //!     for _ in 0..256 {
 //!         let mut val = (0..10000i32).new_value(&mut runner).unwrap();
 //!         if some_function(val.current()) {
@@ -627,7 +627,7 @@
 //! ```rust
 //! extern crate proptest;
 //!
-//! use proptest::test_runner::{Config, TestError, TestRunner};
+//! use proptest::test_runner::{TestError, TestRunner};
 //!
 //! fn some_function(v: i32) {
 //!     // Do a bunch of stuff, but crash if v > 500.
@@ -639,7 +639,7 @@
 //! // We know the function is broken, so use a purpose-built main function to
 //! // find the breaking point.
 //! fn main() {
-//!     let mut runner = TestRunner::new(Config::default());
+//!     let mut runner = TestRunner::default();
 //!     let result = runner.run(&(0..10000i32), |&v| {
 //!         some_function(v);
 //!         Ok(())
@@ -667,7 +667,7 @@
 //! test a function that needs inputs from more than one?
 //!
 //! ```rust,ignore
-//! use proptest::test_runner::{Config, TestRunner};
+//! use proptest::test_runner::TestRunner;
 //!
 //! fn add(a: i32, b: i32) -> i32 {
 //!     a + b
@@ -677,7 +677,7 @@
 //! #[test]
 //! # */
 //! fn test_add() {
-//!     let mut runner = TestRunner::new(Config::default());
+//!     let mut runner = TestRunner::default();
 //!     runner.run(/* uhhm... */).unwrap();
 //! }
 //! #
@@ -696,7 +696,7 @@
 //! So for our two-argument function, our strategy is simply a tuple of ranges.
 //!
 //! ```rust
-//! use proptest::test_runner::{Config, TestRunner};
+//! use proptest::test_runner::TestRunner;
 //!
 //! fn add(a: i32, b: i32) -> i32 {
 //!     a + b
@@ -706,7 +706,7 @@
 //! #[test]
 //! # */
 //! fn test_add() {
-//!     let mut runner = TestRunner::new(Config::default());
+//!     let mut runner = TestRunner::default();
 //!     // Combine our two inputs into a strategy for one tuple. Our test
 //!     // function then destructures the generated tuples back into separate
 //!     // `a` and `b` variables to be passed in to `add()`.
@@ -1287,6 +1287,46 @@
 //! # fn main() { }
 //! ```
 //!
+//! ### Configuring the number of tests cases requried
+//!
+//! The default number of successful test cases that must execute for a test
+//! as a whole to pass is currently 256. If you are not satisfied with this
+//! and want to run more or less there are a few ways to do this.
+//!
+//! The first way is to set the environment-variable `PROPTEST_REQUIRED_CASES`
+//! to a value that can be successfully parsed as a `u32`. The value you set
+//! to this variable is now the new default.
+//!
+//! Another way is to use `#![proptest_config(expr)]` inside `proptest!` where
+//! `expr : Config`. To only change the number of test cases, you can simply
+//! write:
+//! 
+//! ```rust
+//! #[macro_use] extern crate proptest;
+//! use proptest::test_runner::Config;
+//!
+//! fn add(a: i32, b: i32) -> i32 { a + b }
+//!
+//! proptest! {
+//!     // The next line modifies the number of tests.
+//!     #![proptest_config(Config::with_cases(1000))]
+//!     # /*
+//!     #[test]
+//!     # */
+//!     fn test_add(a in 0..1000i32, b in 0..1000i32) {
+//!         let sum = add(a, b);
+//!         assert!(sum >= a);
+//!         assert!(sum >= b);
+//!     }
+//! }
+//! #
+//! # fn main() { test_add(); }
+//! ```
+//! 
+//! Through the same `proptest_config` mechanism you may fine-tune your
+//! configuration through the `Config` type. See its documentation for more
+//! information.
+//!
 //! ### Conclusion
 //!
 //! That's it for the tutorial, at least for now. There are more details for
@@ -1297,6 +1337,7 @@
 #![deny(missing_docs)]
 
 extern crate bit_set;
+#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate quick_error;
 extern crate rand;
 extern crate regex_syntax;

--- a/src/num.rs
+++ b/src/num.rs
@@ -294,6 +294,7 @@ macro_rules! float_bin_search {
                 curr: $typ,
                 hi: $typ,
             }
+
             impl BinarySearch {
                 /// Creates a new binary searcher starting at the given value.
                 pub fn new(start: $typ) -> Self {
@@ -318,6 +319,7 @@ macro_rules! float_bin_search {
                         curr: start,
                     }
                 }
+
 
                 fn reposition(&mut self) -> bool {
                     let interval = self.hi - self.lo;

--- a/src/option.rs
+++ b/src/option.rs
@@ -53,7 +53,7 @@ opaque_strategy_wrapper! {
     /// Constructed by other functions in this module.
     #[derive(Clone)]
     pub struct OptionStrategy[<T>][where T : Strategy]
-        (TupleUnion<((u32,NoneStrategy<<T::Value as ValueTree>::Value>),
+        (TupleUnion<((u32,NoneStrategy<ValueFor<T>>),
                      (u32,statics::Map<T, WrapSome>))>)
         -> OptionValueTree<T::Value>;
     /// `ValueTree` type corresponding to `OptionStrategy`.

--- a/src/option.rs
+++ b/src/option.rs
@@ -53,8 +53,8 @@ opaque_strategy_wrapper! {
     /// Constructed by other functions in this module.
     #[derive(Clone)]
     pub struct OptionStrategy[<T>][where T : Strategy]
-        (TupleUnion<((u32,NoneStrategy<ValueFor<T>>),
-                     (u32,statics::Map<T, WrapSome>))>)
+        (TupleUnion<(W<NoneStrategy<ValueFor<T>>>,
+                     W<statics::Map<T, WrapSome>>)>)
         -> OptionValueTree<T::Value>;
     /// `ValueTree` type corresponding to `OptionStrategy`.
     #[derive(Clone, Debug)]

--- a/src/option.rs
+++ b/src/option.rs
@@ -9,6 +9,9 @@
 
 //! Strategies for generating `std::Option` values.
 
+#![cfg_attr(feature="cargo-clippy",
+    allow(type_complexity, expl_impl_clone_on_copy))]
+
 use std::fmt;
 use std::marker::PhantomData;
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -26,6 +26,9 @@
 //! "maybe err" since the success case results in an easier to understand code
 //! path.
 
+#![cfg_attr(feature="cargo-clippy",
+    allow(type_complexity, expl_impl_clone_on_copy))]
+
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -65,6 +68,10 @@ impl<T : fmt::Debug, E : fmt::Debug> statics::MapFn<E> for WrapErr<T, E> {
     }
 }
 
+type MapErr<T, E> = statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>;
+type MapOk <T, E> = statics::Map<T, WrapOk <ValueFor<T>, ValueFor<E>>>;
+
+#[cfg_attr(feature="cargo-clippy", allow(type_complexity))]
 opaque_strategy_wrapper! {
     /// Strategy which generates `Result`s using `Ok` and `Err` values from two
     /// delegate strategies.
@@ -72,8 +79,7 @@ opaque_strategy_wrapper! {
     /// Shrinks to `Err`.
     #[derive(Clone)]
     pub struct MaybeOk[<T, E>][where T : Strategy, E : Strategy]
-        (TupleUnion<(W<statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>>,
-                     W<statics::Map<T, WrapOk< ValueFor<T>, ValueFor<E>>>>)>)
+        (TupleUnion<(W<MapErr<T, E>>, W<MapOk<T, E>>)>)
         -> MaybeOkValueTree<T::Value, E::Value>;
     /// `ValueTree` type corresponding to `MaybeOk`.
     #[derive(Clone, Debug)]
@@ -83,6 +89,7 @@ opaque_strategy_wrapper! {
         -> Result<T::Value, E::Value>;
 }
 
+#[cfg_attr(feature="cargo-clippy", allow(type_complexity))]
 opaque_strategy_wrapper! {
     /// Strategy which generates `Result`s using `Ok` and `Err` values from two
     /// delegate strategies.
@@ -90,8 +97,7 @@ opaque_strategy_wrapper! {
     /// Shrinks to `Ok`.
     #[derive(Clone)]
     pub struct MaybeErr[<T, E>][where T : Strategy, E : Strategy]
-        (TupleUnion<(W<statics::Map<T, WrapOk<ValueFor<T>, ValueFor<E>>>>,
-                     W<statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>>)>)
+        (TupleUnion<(W<MapOk<T, E>>, W<MapErr<T, E>>)>)
         -> MaybeErrValueTree<T::Value, E::Value>;
     /// `ValueTree` type corresponding to `MaybeErr`.
     #[derive(Clone, Debug)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -72,10 +72,8 @@ opaque_strategy_wrapper! {
     /// Shrinks to `Err`.
     #[derive(Clone)]
     pub struct MaybeOk[<T, E>][where T : Strategy, E : Strategy]
-        (TupleUnion<((u32, statics::Map<E, WrapErr<<T::Value as ValueTree>::Value,
-                                                   <E::Value as ValueTree>::Value>>),
-                     (u32, statics::Map<T, WrapOk<<T::Value as ValueTree>::Value,
-                                                  <E::Value as ValueTree>::Value>>))>)
+        (TupleUnion<((u32, statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>),
+                     (u32, statics::Map<T, WrapOk<ValueFor<T>, ValueFor<E>>>))>)
         -> MaybeOkValueTree<T::Value, E::Value>;
     /// `ValueTree` type corresponding to `MaybeOk`.
     #[derive(Clone, Debug)]
@@ -92,10 +90,8 @@ opaque_strategy_wrapper! {
     /// Shrinks to `Ok`.
     #[derive(Clone)]
     pub struct MaybeErr[<T, E>][where T : Strategy, E : Strategy]
-        (TupleUnion<((u32, statics::Map<T, WrapOk<<T::Value as ValueTree>::Value,
-                                                  <E::Value as ValueTree>::Value>>),
-                     (u32, statics::Map<E, WrapErr<<T::Value as ValueTree>::Value,
-                                                   <E::Value as ValueTree>::Value>>))>)
+        (TupleUnion<((u32, statics::Map<T, WrapOk<ValueFor<T>, ValueFor<E>>>),
+                     (u32, statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>))>)
         -> MaybeErrValueTree<T::Value, E::Value>;
     /// `ValueTree` type corresponding to `MaybeErr`.
     #[derive(Clone, Debug)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -72,8 +72,8 @@ opaque_strategy_wrapper! {
     /// Shrinks to `Err`.
     #[derive(Clone)]
     pub struct MaybeOk[<T, E>][where T : Strategy, E : Strategy]
-        (TupleUnion<((u32, statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>),
-                     (u32, statics::Map<T, WrapOk<ValueFor<T>, ValueFor<E>>>))>)
+        (TupleUnion<(W<statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>>,
+                     W<statics::Map<T, WrapOk< ValueFor<T>, ValueFor<E>>>>)>)
         -> MaybeOkValueTree<T::Value, E::Value>;
     /// `ValueTree` type corresponding to `MaybeOk`.
     #[derive(Clone, Debug)]
@@ -90,8 +90,8 @@ opaque_strategy_wrapper! {
     /// Shrinks to `Ok`.
     #[derive(Clone)]
     pub struct MaybeErr[<T, E>][where T : Strategy, E : Strategy]
-        (TupleUnion<((u32, statics::Map<T, WrapOk<ValueFor<T>, ValueFor<E>>>),
-                     (u32, statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>))>)
+        (TupleUnion<(W<statics::Map<T, WrapOk<ValueFor<T>, ValueFor<E>>>>,
+                     W<statics::Map<E, WrapErr<ValueFor<T>, ValueFor<E>>>>)>)
         -> MaybeErrValueTree<T::Value, E::Value>;
     /// `ValueTree` type corresponding to `MaybeErr`.
     #[derive(Clone, Debug)]

--- a/src/strategy/filter.rs
+++ b/src/strategy/filter.rs
@@ -37,7 +37,7 @@ impl<S : Clone, F> Clone for Filter<S, F> {
         Filter {
             source: self.source.clone(),
             whence: self.whence.clone(),
-            fun: self.fun.clone(),
+            fun: Arc::clone(&self.fun),
         }
     }
 }
@@ -57,7 +57,7 @@ Strategy for Filter<S, F> {
                 return Ok(Filter {
                     source: val,
                     whence: self.whence.clone(),
-                    fun: self.fun.clone(),
+                    fun: Arc::clone(&self.fun),
                 })
             }
         }

--- a/src/strategy/filter.rs
+++ b/src/strategy/filter.rs
@@ -43,7 +43,7 @@ impl<S : Clone, F> Clone for Filter<S, F> {
 }
 
 impl<S : Strategy,
-     F : Fn (&<S::Value as ValueTree>::Value) -> bool>
+     F : Fn (&ValueFor<S>) -> bool>
 Strategy for Filter<S, F> {
     type Value = Filter<S::Value, F>;
 

--- a/src/strategy/flatten.rs
+++ b/src/strategy/flatten.rs
@@ -200,7 +200,7 @@ impl<S : Clone, F> Clone for IndFlattenMap<S, F> {
     fn clone(&self) -> Self {
         IndFlattenMap {
             source: self.source.clone(),
-            fun: self.fun.clone(),
+            fun: Arc::clone(&self.fun),
         }
     }
 }

--- a/src/strategy/flatten.rs
+++ b/src/strategy/flatten.rs
@@ -30,7 +30,7 @@ impl<S : Strategy> Flatten<S> {
 }
 
 impl<S : Strategy> Strategy for Flatten<S>
-where <S::Value as ValueTree>::Value : Strategy {
+where ValueFor<S> : Strategy {
     type Value = FlattenValueTree<S::Value>;
 
     fn new_value(&self, runner: &mut TestRunner)
@@ -89,7 +89,7 @@ impl<S : ValueTree> FlattenValueTree<S> where S::Value : Strategy {
 
 impl<S : ValueTree> ValueTree for FlattenValueTree<S>
 where S::Value : Strategy {
-    type Value = <<S::Value as Strategy>::Value as ValueTree>::Value;
+    type Value = ValueFor<S::Value>;
 
     fn current(&self) -> Self::Value {
         self.current.current()
@@ -168,8 +168,8 @@ where S::Value : Strategy {
 pub struct IndFlatten<S>(pub(super) S);
 
 impl<S : Strategy> Strategy for IndFlatten<S>
-where <S::Value as ValueTree>::Value : Strategy {
-    type Value = <<S::Value as ValueTree>::Value as Strategy>::Value;
+where ValueFor<S> : Strategy {
+    type Value = <ValueFor<S> as Strategy>::Value;
 
     fn new_value(&self, runner: &mut TestRunner)
                  -> Result<Self::Value, String> {
@@ -206,7 +206,7 @@ impl<S : Clone, F> Clone for IndFlattenMap<S, F> {
 }
 
 impl<S : Strategy, R : Strategy,
-     F : Fn (<S::Value as ValueTree>::Value) -> R>
+     F : Fn (ValueFor<S>) -> R>
 Strategy for IndFlattenMap<S, F> {
     type Value = ::tuple::TupleValueTree<(S::Value, R::Value)>;
 

--- a/src/strategy/map.rs
+++ b/src/strategy/map.rs
@@ -40,7 +40,7 @@ impl<S : Clone, F> Clone for Map<S, F> {
 }
 
 impl<S : Strategy, O : fmt::Debug,
-     F : Fn (<S::Value as ValueTree>::Value) -> O>
+     F : Fn (ValueFor<S>) -> O>
 Strategy for Map<S, F> {
     type Value = Map<S::Value, F>;
 

--- a/src/strategy/map.rs
+++ b/src/strategy/map.rs
@@ -34,7 +34,7 @@ impl<S : Clone, F> Clone for Map<S, F> {
     fn clone(&self) -> Self {
         Map {
             source: self.source.clone(),
-            fun: self.fun.clone(),
+            fun: Arc::clone(&self.fun),
         }
     }
 }
@@ -47,7 +47,7 @@ Strategy for Map<S, F> {
     fn new_value(&self, runner: &mut TestRunner)
                  -> Result<Self::Value, String> {
         self.source.new_value(runner).map(
-            |v| Map { source: v, fun: self.fun.clone() })
+            |v| Map { source: v, fun: Arc::clone(&self.fun) })
     }
 }
 

--- a/src/strategy/statics.rs
+++ b/src/strategy/statics.rs
@@ -11,8 +11,8 @@
 //! traits instead of normal functions.
 //!
 //! This entire module is strictly a workaround until
-//! https://github.com/rust-lang/rfcs/pull/1522 and
-//! https://github.com/rust-lang/rfcs/pull/2071 are available in stable. It
+//! <https://github.com/rust-lang/rfcs/pull/1522> and
+//! <https://github.com/rust-lang/rfcs/pull/2071> are available in stable. It
 //! allows naming types built on the combinators without resorting to dynamic
 //! dispatch or causing `Arc` to allocate space for a function pointer.
 //!

--- a/src/strategy/statics.rs
+++ b/src/strategy/statics.rs
@@ -62,7 +62,7 @@ impl<S : fmt::Debug, F> fmt::Debug for Filter<S, F> {
 }
 
 impl<S : Strategy,
-     F : FilterFn<<S::Value as ValueTree>::Value> + Clone>
+     F : FilterFn<ValueFor<S>> + Clone>
 Strategy for Filter<S, F> {
     type Value = Filter<S::Value, F>;
 
@@ -153,7 +153,7 @@ impl<S : fmt::Debug, F> fmt::Debug for Map<S, F> {
 }
 
 impl<S : Strategy,
-     F : Clone + MapFn<<S::Value as ValueTree>::Value>>
+     F : Clone + MapFn<ValueFor<S>>>
 Strategy for Map<S, F> {
     type Value = Map<S::Value, F>;
 

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -13,6 +13,9 @@ use std::sync::Arc;
 use strategy::*;
 use test_runner::*;
 
+/// The value that functions under test use for a particular `Strategy`.
+type ValueFor<S> = <<S as Strategy>::Value as ValueTree>::Value;
+
 /// A strategy for producing arbitrary values of a given type.
 ///
 /// `fmt::Debug` is a hard requirement for all strategies currently due to

--- a/src/strategy/unions.rs
+++ b/src/strategy/unions.rs
@@ -228,8 +228,7 @@ macro_rules! tuple_union {
     ($($gen:ident $ix:tt)*) => {
         impl<A : Strategy, $($gen: Strategy),*> Strategy
         for TupleUnion<((u32, A), $((u32, $gen)),*)>
-        where $($gen::Value : ValueTree<Value =
-                <A::Value as ValueTree>::Value>),* {
+        where $($gen::Value : ValueTree<Value = ValueFor<A>>),* {
             type Value = TupleUnionValueTree<
                 (A::Value, $(Option<$gen::Value>),*)>;
 

--- a/src/strategy/unions.rs
+++ b/src/strategy/unions.rs
@@ -42,7 +42,7 @@ impl<T : Strategy> Union<T> {
     pub fn new<I : IntoIterator<Item = T>>(options: I) -> Self {
         let options: Vec<W<T>> = options.into_iter()
             .map(|v| (1, v)).collect();
-        assert!(options.len() > 0);
+        assert!(!options.is_empty());
 
         Union { options }
     }
@@ -60,11 +60,11 @@ impl<T : Strategy> Union<T> {
     ///
     /// Panics if the sum of the weights overflows a `u32`.
     pub fn new_weighted(options: Vec<W<T>>) -> Self {
-        assert!(options.len() > 0);
+        assert!(!options.is_empty());
         assert!(!options.iter().any(|&(w, _)| 0 == w),
                 "Union option has a weight of 0");
-        assert!(options.iter().map(|&(w, _)| w as u64).sum::<u64>() <=
-                u32::MAX as u64, "Union weights overflow u32");
+        assert!(options.iter().map(|&(w, _)| u64::from(w)).sum::<u64>() <=
+                u64::from(u32::MAX), "Union weights overflow u32");
         Union { options }
     }
 
@@ -298,7 +298,7 @@ value_tree_tuple!(access_tuple8, B C D E F G H);
 value_tree_tuple!(access_tuple9, B C D E F G H I);
 value_tree_tuple!(access_tupleA, B C D E F G H I J);
 
-const WEIGHT_BASE: u32 = 0x80000000;
+const WEIGHT_BASE: u32 = 0x8000_0000;
 
 /// Convert a floating-point weight in the range (0.0,1.0) to a pair of weights
 /// that can be used with `Union` and similar.
@@ -319,7 +319,7 @@ pub fn float_to_weight(f: f64) -> (u32, u32) {
 
     // Clamp to 1..WEIGHT_BASE-1 so that we never produce a weight of 0.
     let pos = max(1, min(WEIGHT_BASE - 1,
-                         (f * WEIGHT_BASE as f64).round() as u32));
+                         (f * f64::from(WEIGHT_BASE)).round() as u32));
     let neg = WEIGHT_BASE - pos;
 
     (pos, neg)

--- a/src/string.rs
+++ b/src/string.rs
@@ -99,7 +99,7 @@ pub fn bytes_regex_parsed(expr: &rs::Expr)
     match *expr {
         Empty => Ok(Just(vec![]).boxed()),
         Literal { ref chars, casei: false } =>
-            Ok(Just(chars.iter().map(|&c| c).collect::<String>()
+            Ok(Just(chars.iter().cloned().collect::<String>()
                          .into_bytes()).boxed()),
         Literal { ref chars, casei: true } => {
             let chars = chars.to_owned();
@@ -124,7 +124,7 @@ pub fn bytes_regex_parsed(expr: &rs::Expr)
                          .collect::<Vec<_>>()).boxed())
         },
 
-        AnyChar => Ok(char::ANY.boxed().prop_map(|c| to_bytes(c)).boxed()),
+        AnyChar => Ok(char::ANY.boxed().prop_map(to_bytes).boxed()),
         AnyCharNoNL => {
             static NONL_RANGES: &[(char,char)] = &[
                 ('\x00', '\x09'),
@@ -138,7 +138,7 @@ pub fn bytes_regex_parsed(expr: &rs::Expr)
                 ('\x0B', ::std::char::MAX),
             ];
             Ok(char::ranges(Cow::Borrowed(NONL_RANGES))
-               .prop_map(|c| to_bytes(c)).boxed())
+               .prop_map(to_bytes).boxed())
         },
         AnyByte => Ok(num::u8::ANY.prop_map(|b| vec![b]).boxed()),
         AnyByteNoNL => Ok((0xBu8..).boxed()
@@ -239,7 +239,7 @@ fn flip_case_to_bytes(flip: bool, ch: char) -> Vec<u8> {
 }
 
 fn to_bytes(ch: char) -> Vec<u8> {
-    [ch].iter().map(|&c|c).collect::<String>().into_bytes()
+    [ch].iter().cloned().collect::<String>().into_bytes()
 }
 
 fn flip_ascii_case(flip: bool, ch: u8) -> u8 {

--- a/src/string.rs
+++ b/src/string.rs
@@ -266,7 +266,7 @@ mod test {
         let mut generated = HashSet::new();
 
         let strategy = string_regex(pattern).unwrap();
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..iterations {
             let mut value = strategy.new_value(&mut runner).unwrap();
 

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -236,10 +236,9 @@ impl TestRunner {
     ///
     /// Returns success or failure indicating why the test as a whole failed.
     pub fn run<S : Strategy,
-               F : Fn (&<S::Value as ValueTree>::Value)
-                       -> TestCaseResult>
+               F : Fn (&ValueFor<S>) -> TestCaseResult>
         (&mut self, strategy: &S, f: F)
-         -> Result<(), TestError<<S::Value as ValueTree>::Value>>
+         -> Result<(), TestError<ValueFor<S>>>
     {
         while self.successes < self.config.cases {
             let case = match strategy.new_value(self) {

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -188,6 +188,12 @@ impl fmt::Display for TestRunner {
     }
 }
 
+impl Default for TestRunner {
+    fn default() -> Self {
+        Self::new(Config::default())
+    }
+}
+
 impl TestRunner {
     /// Create a fresh `TestRunner` with the given configuration.
     pub fn new(config: Config) -> Self {
@@ -393,14 +399,14 @@ mod test {
 
     #[test]
     fn test_pass() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let result = runner.run(&(1u32..), |&v| { assert!(v > 0); Ok(()) });
         assert_eq!(Ok(()), result);
     }
 
     #[test]
     fn test_fail_via_result() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let result = runner.run(&(0u32..10u32), |&v| if v < 5 {
             Ok(())
         } else {
@@ -413,7 +419,7 @@ mod test {
 
     #[test]
     fn test_fail_via_panic() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let result = runner.run(&(0u32..10u32), |&v| {
             assert!(v < 5, "not less than 5");
             Ok(())

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -38,7 +38,7 @@ lazy_static! {
                     "The env-var PROPTEST_REQUIRED_CASES can't be parsed as u32.")
             }
         }
-        return FALLBACK_DEFAULT_CASES;
+        FALLBACK_DEFAULT_CASES
     };
 }
 
@@ -343,7 +343,7 @@ impl TestRunner {
                 Err(TestError::Fail(last_failure.0, last_failure.1))
             },
             Err(TestCaseError::Reject(whence)) => {
-                self.reject_global(whence)?;
+                self.reject_global(&whence)?;
                 Ok(false)
             },
         }
@@ -374,13 +374,13 @@ impl TestRunner {
 
     /// Update the state to account for a global rejection from `whence`, and
     /// return `Ok` if the caller should keep going or `Err` to abort.
-    fn reject_global<T>(&mut self, whence: String) -> Result<(),TestError<T>> {
+    fn reject_global<T>(&mut self, whence: &str) -> Result<(),TestError<T>> {
         if self.global_rejects >= self.config.max_global_rejects {
             Err(TestError::Abort("Too many global rejects".to_owned()))
         } else {
             self.global_rejects += 1;
             let need_insert = if let Some(count) =
-                self.global_reject_detail.get_mut(&whence)
+                self.global_reject_detail.get_mut(whence)
             {
                 *count += 1;
                 false
@@ -388,7 +388,7 @@ impl TestRunner {
                 true
             };
             if need_insert {
-                self.global_reject_detail.insert(whence.clone(), 1);
+                self.global_reject_detail.insert(whence.to_owned(), 1);
             }
 
             Ok(())

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -56,9 +56,9 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             cases: 256,
-            max_local_rejects: 65536,
+            max_local_rejects: 65_536,
             max_global_rejects: 1024,
-            max_flat_map_regens: 1000000,
+            max_flat_map_regens: 1_000_000,
             _non_exhaustive: (),
         }
     }
@@ -212,7 +212,7 @@ impl TestRunner {
             local_rejects: 0,
             global_rejects: 0,
             rng: rand::weak_rng(),
-            flat_map_regens: self.flat_map_regens.clone(),
+            flat_map_regens: Arc::clone(&self.flat_map_regens),
             local_reject_detail: BTreeMap::new(),
             global_reject_detail: BTreeMap::new(),
         }
@@ -285,11 +285,10 @@ impl TestRunner {
                 if case.simplify() {
                     loop {
                         let passed = match test!(case.current()) {
-                            Ok(_) => true,
                             // Rejections are effectively a pass here,
                             // since they indicate that any behaviour of
                             // the function under test is acceptable.
-                            Err(TestCaseError::Reject(..)) => true,
+                            Ok(_) | Err(TestCaseError::Reject(..)) => true,
 
                             Err(TestCaseError::Fail(why)) => {
                                 last_failure = (why, case.current());
@@ -301,10 +300,8 @@ impl TestRunner {
                             if !case.complicate() {
                                 break;
                             }
-                        } else {
-                            if !case.simplify() {
-                                break;
-                            }
+                        } else if !case.simplify() {
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds:
1. Added a type alias `ValueFor<S>` where `S: Strategy`. This is a shorter way
  to refer to: `<<S as Strategy>::Value as ValueTree>::Value`.

2. Added a type alias `type W<T> = (u32, T)` for a weighted strategy `T` in the
  context of union strategies.

3. `TestRunner` now implements `Default`.

4. Added `Config::with_cases(number_of_cases: u32) -> Config` for simpler
  construction of a `Config` that only differs by the number of test cases.

5. The default number of test cases to run is `256` (as before). This default
  which is encoded by `Config::default()` is now configurable by setting the
  env-var `PROPTEST_REQUIRED_CASES` to a value that can be parsed as a `u32`.
  This variable is read at runtime.

6. bumped dependency `rand = "0.3.18"`.

7. Added `proptest::collection::subsequence<T: Clone>(Vec<T>, Range<usize>)`
  which returns a strategy generating subsequences, of the source `Vec`,
  with a size within the given `Range`.

8. Added the trait `CollectionStrategy` which provides `.prop_sample` directly
  on collection types. The operation is the same as `subsequence` for `Vec`.

And then bumps the version to `0.3.2`.

Point 1. makes documentation quite more readable and it's a bit easier now to construct your own generic strategies.

Point 2. makes working with unions a bit more readable too, but this was less important.

I also ran `cargo clippy` and applied some of its suggestions.