### PR TITLE
Change return type of new_value to compact repr + type alias for it, Add TestCaseError::{reject, fail}, reject_case, fail_case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 
 # VSCode:
 .vscode/
+persistence-test.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 0.4.0
+
+### Potential Breaking Changes
+
+- Instead of returning `-> Result<Self::Value, String>`, strategies are expected
+  to return `-> Result<Self::Value, Rejection>` instead. `Rejection` reduces
+  the amount of heap allocations, especially for `.prop_filter(..)` where
+  you may now also pass in `&'static str` as well as `Rc<str>`.
+  You will only experience breaks if you've written your own strategy types
+  or if you've used `TestCaseError::Reject` or `TestCaseError::Fail` expliclty.
+
+### New Additions
+
+- Added `proptest::strategy::Rejection` which allows you to avoid heap allocation
+  in some places or share allocation with string-interning.
+
+- Added a type alias `proptest::strategy::NewTree<S>` where `S: Strategy`
+  defined as: `type NewTree<S> = Result<<S as Strategy>::Value, Rejection>`.
+
+- Added `TestCaseError::reject` and `reject_case` (short-hand).
+
+- Added `TestCaseError::fail` and `fail_case` (short-hand).
+
 ## 0.3.2
 
 ### New Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,58 @@
-## 0.4.0
+## Unreleased
 
 ### Potential Breaking Changes
 
-- Instead of returning `-> Result<Self::Value, String>`, strategies are expected
-  to return `-> Result<Self::Value, Rejection>` instead. `Rejection` reduces
-  the amount of heap allocations, especially for `.prop_filter(..)` where
-  you may now also pass in `&'static str` as well as `Rc<str>`.
+- Instead of returning `-> Result<Self::Value, String>`, strategies are
+  expected to return `-> Result<Self::Value, Rejection>` instead. `Rejection`
+  somewhat reduces the amount of heap allocations, especially for
+  `.prop_filter(..)` where you may now also pass in `&'static str`.
   You will only experience breaks if you've written your own strategy types
   or if you've used `TestCaseError::Reject` or `TestCaseError::Fail` expliclty.
 
 ### New Additions
 
-- Added `proptest::strategy::Rejection` which allows you to avoid heap allocation
-  in some places or share allocation with string-interning.
+- Added `proptest::strategy::Rejection` which is simply a wrapper around
+  `Cow<'static, str>` for now. We are doing this breaking change now so
+  that we have the option to change it later if we need to.
 
 - Added a type alias `proptest::strategy::NewTree<S>` where `S: Strategy`
   defined as: `type NewTree<S> = Result<<S as Strategy>::Value, Rejection>`.
 
-- Added `TestCaseError::reject` and `reject_case` (short-hand).
+## 0.3.4
 
-- Added `TestCaseError::fail` and `fail_case` (short-hand).
+### Bug Fixes
+
+- Cases where `file!()` returns a relative path, such as on Windows, are now
+  handled more reasonably. See
+  [#24](https://github.com/AltSysrq/proptest/issues/24) for more details and
+  instructions on how to migrate any persistence files that had been written to
+  the wrong location.
+
+## 0.3.3
+
+Boxing Day Special
+
+### New Additions
+
+- Added support for `i128` and `u128`. Since this is an unstable feature in
+  Rust, this is hidden behind the feature `unstable` which you have to
+  explicitly opt into in your `Cargo.toml` file.
+
+- Failing case persistence. By default, when a test fails, Proptest will now
+  save the seed for the failing test to a file, and later runs will test the
+  persisted failing cases before generating new ones.
+
+- Added `UniformArrayStrategy` and helper functions to simplify generating
+  homogeneous arrays with non-`Copy` inner strategies.
+
+- Trait `rand::Rng` and struct `rand::XorShiftRng` are now included in
+  `proptest::prelude`.
+
+### Bug Fixes
+
+- Fix a case where certain combinations of strategies, like two
+  `prop_shuffle()`s in close proximity, could result in low-quality randomness.
+>>>>>>> c27ee2487de915a3953d7ee665fce807cb3e8336
 
 ## 0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ Boxing Day Special
 
 - Fix a case where certain combinations of strategies, like two
   `prop_shuffle()`s in close proximity, could result in low-quality randomness.
->>>>>>> c27ee2487de915a3953d7ee665fce807cb3e8336
 
 ## 0.3.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proptest"
-version = "0.3.2"
+version = "0.3.4"
 authors = ["Jason Lingle"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -15,6 +15,13 @@ Hypothesis-like property-based testing and shrinking.
 
 [badges]
 travis-ci = { repository = "AltSysrq/proptest" }
+
+[features]
+
+default = []
+
+# Enables unstable features of Rust.
+unstable = []
 
 [dependencies]
 bit-set = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ minimal test case to reproduce the problem. Unlike QuickCheck, generation
 and shrinking is defined on a per-value basis instead of per-type, which
 makes it much more flexible and simplifies composition.
 
+If you have dependencies which provide QuickCheck `Arbitrary`
+implementations, see also the related
+[`proptest-quickcheck-interop`](https://crates.io/crates/proptest-quickcheck-interop)
+crates which enables reusing those implementations with proptest.
+
 ## Status of this crate
 
 The majority of the functionality offered by proptest is in active use and
@@ -79,7 +84,7 @@ In `Cargo.toml`, add
 
 ```toml
 [dev-dependencies]
-proptest = "0.3.2"
+proptest = "0.3.4"
 ```
 
 and at the top of `main.rs` or `lib.rs`:
@@ -120,8 +125,19 @@ thread 'main' panicked at 'Test failed: byte index 4 is not a char boundary; it 
 '
 ```
 
-The first thing we should do is copy the failing case to a traditional unit
-test since it has exposed a bug.
+If we look at the top directory after the test fails, we'll see a new
+`proptest-regressions` directory, which contains some files corresponding
+to source files containing failing test cases. These are [_failure
+persistence_](#failure-persistence) files. The first thing we should do is
+add these to source control.
+
+```text
+$ git add proptest-regressions
+```
+
+The next thing we should do is copy the failing case to a traditional unit
+test since it has exposed a bug not similar to what we've tested in the
+past.
 
 ```rust
 #[test]
@@ -138,8 +154,6 @@ In the interest of making the code changes as small as possible, we'll just
 check that the string is ASCII and reject anything that isn't.
 
 ```rust
-use std::ascii::AsciiExt;
-
 fn parse_date(s: &str) -> Option<(u32, u32, u32)> {
     if 10 != s.len() { return None; }
 
@@ -270,7 +284,12 @@ Between those two, though, we see something different: it tried to shrink
 the `0000-06-20` and `0000-09-20` test cases _passed_.
 
 In the end, we get the date `0000-10-01`, which apparently gets parsed as
-`0000-00-01`. Again, let's add this as its own unit test:
+`0000-00-01`. Again, this failing case was added to the failure persistence
+file, and we should add this as its own unit test:
+
+```text
+$ git add proptest-regressions
+```
 
 ```rust
 #[test]
@@ -379,6 +398,47 @@ Similarly, in some cases it can be hard or impossible to define a strategy
 which actually produces useful inputs. A strategy of `.{1,4096}` may be
 great to fuzz a C parser, but is highly unlikely to produce anything that
 makes it to a code generator.
+
+## Failure Persistence
+
+By default, when Proptest finds a failing test case, it _persists_ that
+failing case in a file named after the source containing the failing test,
+but in a separate directory tree rooted at `proptest-regressions`† . Later
+runs of tests will replay those test cases before generating novel cases.
+This ensures that the test will not fail on one run and then spuriously
+pass on the next, and also exposes similar tests to the same
+known-problematic input.
+
+(†  If you do not have an obvious source directory, you may instead find
+files next to the source files, with a different extension.)
+
+It is recommended to check these files in to your source control so that
+other test runners (e.g., collaborators or a CI system) also replay these
+cases.
+
+Note that, by default, all tests in the same crate will share that one
+persistence file. If you have a very large number of tests, it may be
+desirable to separate them into smaller groups so the number of extra test
+cases that get run is reduced. This can be done by adjusting the
+`failure_persistence` flag on `Config`.
+
+There are two ways this persistence could theoretically be done.
+
+The immediately obvious option is to persist a representation of the value
+itself, for example by using Serde. While this has some advantages,
+particularly being resistant to changes like tweaking the input strategy,
+it also has a lot of problems. Most importantly, there is no way to
+determine whether any given value is actually within the domain of the
+strategy that produces it. Thus, some (likely extremely fragile) mechanism
+to ensure that the strategy that produced the value exactly matches the one
+in use in a test case would be required.
+
+The other option is to store the _seed_ that was used to produce the
+failing test case. This approach requires no support from the strategy or
+the produced value. If the strategy in use differs from the one used to
+produce failing case that was persisted, the seed may or may not produce
+the problematic value, but nonetheless produces a valid value. Due to these
+advantages, this is the approach Proptest uses.
 
 
 # Acknowledgements

--- a/examples/dateparser_v2.rs
+++ b/examples/dateparser_v2.rs
@@ -9,6 +9,8 @@
 
 #[macro_use] extern crate proptest;
 
+// Needed for Rust 1.22.1 compatibility
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 fn parse_date(s: &str) -> Option<(u32, u32, u32)> {

--- a/examples/tutorial-simplify-play.rs
+++ b/examples/tutorial-simplify-play.rs
@@ -14,11 +14,11 @@
 
 extern crate proptest;
 
-use proptest::test_runner::{Config, TestRunner};
+use proptest::test_runner::TestRunner;
 use proptest::strategy::{Strategy, ValueTree};
 
 fn main() {
-    let mut runner = TestRunner::new(Config::default());
+    let mut runner = TestRunner::default();
     let mut str_val = "[a-z]{1,4}\\p{Cyrillic}{1,4}\\p{Greek}{1,4}"
         .new_value(&mut runner).unwrap();
     println!("str_val = {}", str_val.current());

--- a/examples/tutorial-strategy-play.rs
+++ b/examples/tutorial-strategy-play.rs
@@ -14,11 +14,11 @@
 
 extern crate proptest;
 
-use proptest::test_runner::{Config, TestRunner};
+use proptest::test_runner::TestRunner;
 use proptest::strategy::{Strategy, ValueTree};
 
 fn main() {
-    let mut runner = TestRunner::new(Config::default());
+    let mut runner = TestRunner::default();
     let int_val = (0..100i32).new_value(&mut runner).unwrap();
     let str_val = "[a-z]{1,4}\\p{Cyrillic}{1,4}\\p{Greek}{1,4}"
         .new_value(&mut runner).unwrap();

--- a/src/array.rs
+++ b/src/array.rs
@@ -9,13 +9,68 @@
 
 //! Support for strategies producing fixed-length arrays.
 //!
-//! There is no explicit type for array strategies; instead, simply make an
-//! array containing the desired strategy(ies) of the desired length.
+//! An array of strategies (but only length 1 to 32 for now) is itself a
+//! strategy which generates arrays of that size drawing elements from the
+//! corresponding input strategies.
+//!
+//! See also [`UniformArrayStrategy`](struct.UniformArrayStrategy.html) for
+//! easily making a strategy for an array drawn from one strategy.
 //!
 //! General implementations are available for sizes 1 through 32.
 
+use std::marker::PhantomData;
+
 use strategy::*;
 use test_runner::*;
+
+/// A `Strategy` which generates fixed-size arrays containing values drawn from
+/// an inner strategy.
+///
+/// `T` must be an array type of length 1 to 32 whose values are produced by
+/// strategy `S`. Instances of this type are normally created by the various
+/// `uniformXX` functions in this module.
+///
+/// This is mainly useful when the inner strategy is not `Copy`, precluding
+/// expressing the strategy as `[myStrategy; 32]`, for example.
+///
+/// ## Example
+///
+/// ```
+/// #[macro_use] extern crate proptest;
+/// use proptest::prelude::*;
+///
+/// proptest! {
+///   #[test]
+///   fn test_something(a in prop::array::uniform32(1u32..)) {
+///     let unexpected = [0u32;32];
+///     // `a` is also a [u32;32], so we can compare them directly
+///     assert_ne!(unexpected, a);
+///   }
+/// }
+/// # fn main() { }
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct UniformArrayStrategy<S, T> {
+    strategy: S,
+    _marker: PhantomData<T>,
+}
+
+impl<S, T> UniformArrayStrategy<S, T> {
+    /// Directly create a `UniformArrayStrategy`.
+    ///
+    /// This is only intended for advanced use, since the only way to specify
+    /// the array size is with the turbofish operator and explicitly naming the
+    /// type of the values in the array and the strategy itself.
+    ///
+    /// Prefer the `uniformXX` functions at module-level unless something
+    /// precludes their use.
+    pub fn new(strategy: S) -> Self {
+        UniformArrayStrategy {
+            strategy,
+            _marker: PhantomData,
+        }
+    }
+}
 
 /// A `ValueTree` operating over a fixed-size array.
 #[derive(Clone, Copy, Debug)]
@@ -26,13 +81,46 @@ pub struct ArrayValueTree<T> {
 }
 
 macro_rules! small_array {
-    ($n:tt : $($ix:expr),*) => {
+    ($n:tt $uni:ident : $($ix:expr),*) => {
+        /// Create a strategy to generate fixed-length arrays.
+        ///
+        /// All values within the new strategy are generated using the given
+        /// strategy. The length of the array corresponds to the suffix of the
+        /// name of this function.
+        ///
+        /// See [`UniformArrayStrategy`](struct.UniformArrayStrategy.html) for
+        /// example usage.
+        pub fn $uni<S : Strategy>
+            (strategy: S) -> UniformArrayStrategy<S, [ValueFor<S>; $n]>
+        {
+            UniformArrayStrategy {
+                strategy,
+                _marker: PhantomData
+            }
+        }
+
         impl<S : Strategy> Strategy for [S;$n] {
             type Value = ArrayValueTree<[S::Value;$n]>;
 
             fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(ArrayValueTree {
                     tree: [$(self[$ix].new_value(runner)?,)*],
+                    shrinker: 0,
+                    last_shrinker: None,
+                })
+            }
+        }
+
+        impl<S : Strategy> Strategy
+        for UniformArrayStrategy<S, [ValueFor<S>; $n]> {
+            type Value = ArrayValueTree<[S::Value; $n]>;
+
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                Ok(ArrayValueTree {
+                    tree: [$({
+                        let _ = $ix;
+                        self.strategy.new_value(runner)?
+                    },)*],
                     shrinker: 0,
                     last_shrinker: None,
                 })
@@ -76,52 +164,84 @@ macro_rules! small_array {
     }
 }
 
-small_array!(1: 0);
-small_array!(2: 0, 1);
-small_array!(3: 0, 1, 2);
-small_array!(4: 0, 1, 2, 3);
-small_array!(5: 0, 1, 2, 3, 4);
-small_array!(6: 0, 1, 2, 3, 4, 5);
-small_array!(7: 0, 1, 2, 3, 4, 5, 6);
-small_array!(8: 0, 1, 2, 3, 4, 5, 6, 7);
-small_array!(9: 0, 1, 2, 3, 4, 5, 6, 7, 8);
-small_array!(10: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-small_array!(11: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-small_array!(12: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-small_array!(13: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-small_array!(14: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-small_array!(15: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-small_array!(16: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-small_array!(17: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-small_array!(18: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17);
-small_array!(19: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18);
-small_array!(20: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19);
-small_array!(21: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20);
-small_array!(22: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21);
-small_array!(23: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22);
-small_array!(24: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23);
-small_array!(25: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24);
-small_array!(26: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24, 25);
-small_array!(27: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24, 25, 26);
-small_array!(28: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24, 25, 26, 27);
-small_array!(29: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28);
-small_array!(30: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29);
-small_array!(31: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
-small_array!(32: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
+small_array!(1 uniform1:
+             0);
+small_array!(2 uniform2:
+             0, 1);
+small_array!(3 uniform3:
+             0, 1, 2);
+small_array!(4 uniform4:
+             0, 1, 2, 3);
+small_array!(5 uniform5:
+             0, 1, 2, 3, 4);
+small_array!(6 uniform6:
+             0, 1, 2, 3, 4, 5);
+small_array!(7 uniform7:
+             0, 1, 2, 3, 4, 5, 6);
+small_array!(8 uniform8:
+             0, 1, 2, 3, 4, 5, 6, 7);
+small_array!(9 uniform9:
+             0, 1, 2, 3, 4, 5, 6, 7, 8);
+small_array!(10 uniform10:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+small_array!(11 uniform11:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+small_array!(12 uniform12:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+small_array!(13 uniform13:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+small_array!(14 uniform14:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+small_array!(15 uniform15:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+small_array!(16 uniform16:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+small_array!(17 uniform17:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+small_array!(18 uniform18:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17);
+small_array!(19 uniform19:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18);
+small_array!(20 uniform20:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19);
+small_array!(21 uniform21:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20);
+small_array!(22 uniform22:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21);
+small_array!(23 uniform23:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22);
+small_array!(24 uniform24:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23);
+small_array!(25 uniform25:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24);
+small_array!(26 uniform26:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24, 25);
+small_array!(27 uniform27:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24, 25, 26);
+small_array!(28 uniform28:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24, 25, 26, 27);
+small_array!(29 uniform29:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28);
+small_array!(30 uniform30:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29);
+small_array!(31 uniform31:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
+small_array!(32 uniform32:
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
 
 #[cfg(test)]
 mod test {

--- a/src/array.rs
+++ b/src/array.rs
@@ -134,7 +134,7 @@ mod test {
         }
 
         let input = [0..32, 0..32];
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
 
         let mut cases_tested = 0;
         for _ in 0..256 {

--- a/src/array.rs
+++ b/src/array.rs
@@ -30,8 +30,7 @@ macro_rules! small_array {
         impl<S : Strategy> Strategy for [S;$n] {
             type Value = ArrayValueTree<[S::Value;$n]>;
 
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<Self::Value, String> {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(ArrayValueTree {
                     tree: [$(self[$ix].new_value(runner)?,)*],
                     shrinker: 0,

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -151,8 +151,7 @@ impl<T : BitSetLike> BitSetStrategy<T> {
 impl<T : BitSetLike> Strategy for BitSetStrategy<T> {
     type Value = BitSetValueTree<T>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let mut inner = T::new_bitset(self.max);
         for bit in self.min..self.max {
             if self.mask.as_ref().map_or(true, |mask| mask.test(bit)) &&
@@ -212,8 +211,7 @@ impl<T : BitSetLike> SampledBitSetStrategy<T> {
 impl<T : BitSetLike> Strategy for SampledBitSetStrategy<T> {
     type Value = BitSetValueTree<T>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let mut bits = T::new_bitset(self.bits.end);
         let count = runner.rng().gen_range(self.size.start, self.size.end);
         for bit in rand::sample(runner.rng(), self.bits.clone(), count) {

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -368,7 +368,7 @@ mod test {
     fn generates_values_in_range() {
         let input = u32::between(4, 8);
 
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..256 {
             let value = input.new_value(&mut runner).unwrap().current();
             assert!(0 == value & !0xF0u32,
@@ -380,7 +380,7 @@ mod test {
     fn generates_values_in_mask() {
         let mut accum = 0;
 
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let input = u32::masked(0xdeadbeef);
         for _ in 0..1024 {
             accum |= input.new_value(&mut runner).unwrap().current();
@@ -398,7 +398,7 @@ mod test {
         mask.insert(0);
         mask.insert(2);
 
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let input = bitset::masked(mask);
         for _ in 0..32 {
             let v = input.new_value(&mut runner).unwrap().current();
@@ -414,7 +414,7 @@ mod test {
     fn shrinks_to_zero() {
         let input = u32::between(4, 24);
 
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..256 {
             let mut value = input.new_value(&mut runner).unwrap();
             let mut prev = value.current();
@@ -433,7 +433,7 @@ mod test {
     fn complicates_to_previous() {
         let input = u32::between(4, 24);
 
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..256 {
             let mut value = input.new_value(&mut runner).unwrap();
             let orig = value.current();

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -26,8 +26,7 @@ pub const ANY: Any = Any(());
 impl Strategy for Any {
     type Value = BoolValueTree;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<BoolValueTree, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         Ok(BoolValueTree(runner.rng().gen()))
     }
 }
@@ -47,8 +46,7 @@ pub struct Weighted(f64);
 impl Strategy for Weighted {
     type Value = BoolValueTree;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<BoolValueTree, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         Ok(BoolValueTree(runner.rng().next_f64() < self.0))
     }
 }

--- a/src/char.rs
+++ b/src/char.rs
@@ -227,8 +227,7 @@ pub struct CharValueTree {
 impl<'a> Strategy for CharStrategy<'a> {
     type Value = CharValueTree;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<CharValueTree, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let (base, offset) = select_range_index(
             runner.rng(), &self.special, &self.preferred, &self.ranges);
 
@@ -311,7 +310,7 @@ mod test {
                         |lo| ::std::char::from_u32(hi).map(
                             |hi| (min(lo, hi), max(lo, hi))))
                         .ok_or_else(|| TestCaseError::Reject(
-                            "non-char".to_owned())))
+                            reject("non-char"))))
                     .collect::<Result<Vec<CharRange>,_>>()?));
 
                 let mut runner = TestRunner::new(Config::default());

--- a/src/char.rs
+++ b/src/char.rs
@@ -303,7 +303,7 @@ mod test {
             (0..::std::char::MAX as u32,
              0..::std::char::MAX as u32),
             1..5);
-        TestRunner::new(Config::default()).run(
+        TestRunner::default().run(
             &meta_input, |input_ranges| {
                 let input = ranges(Cow::Owned(input_ranges.iter().map(
                     |&(lo, hi)| ::std::char::from_u32(lo).and_then(
@@ -313,7 +313,7 @@ mod test {
                             reject("non-char"))))
                     .collect::<Result<Vec<CharRange>,_>>()?));
 
-                let mut runner = TestRunner::new(Config::default());
+                let mut runner = TestRunner::default();
                 for _ in 0..256 {
                     let mut value = input.new_value(&mut runner).unwrap();
                     loop {
@@ -334,7 +334,7 @@ mod test {
     fn applies_desired_bias() {
         let mut men_in_business_suits_levitating = 0;
         let mut ascii_printable = 0;
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
 
         for _ in 0..1024 {
             let ch = ANY.new_value(&mut runner).unwrap().current();
@@ -352,7 +352,7 @@ mod test {
     #[test]
     fn doesnt_shrink_to_ascii_control() {
         let mut accepted = 0;
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
 
         for _ in 0..256 {
             let mut value = ANY.new_value(&mut runner).unwrap();

--- a/src/char.rs
+++ b/src/char.rs
@@ -309,8 +309,7 @@ mod test {
                     |&(lo, hi)| ::std::char::from_u32(lo).and_then(
                         |lo| ::std::char::from_u32(hi).map(
                             |hi| (min(lo, hi), max(lo, hi))))
-                        .ok_or_else(|| TestCaseError::Reject(
-                            reject("non-char"))))
+                        .ok_or_else(|| reject_case("non-char")))
                     .collect::<Result<Vec<CharRange>,_>>()?));
 
                 let mut runner = TestRunner::default();

--- a/src/char.rs
+++ b/src/char.rs
@@ -309,7 +309,7 @@ mod test {
                     |&(lo, hi)| ::std::char::from_u32(lo).and_then(
                         |lo| ::std::char::from_u32(hi).map(
                             |hi| (min(lo, hi), max(lo, hi))))
-                        .ok_or_else(|| reject_case("non-char")))
+                        .ok_or_else(|| TestCaseError::reject("non-char")))
                     .collect::<Result<Vec<CharRange>,_>>()?));
 
                 let mut runner = TestRunner::default();

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -470,7 +470,7 @@ mod test {
                 if v.iter().map(|&v| v).sum::<usize>() < 9 {
                     Ok(())
                 } else {
-                    fail_case("greater than 8")
+                    Err(TestCaseError::fail("greater than 8"))
                 }
             });
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -178,7 +178,7 @@ where ValueFor<T> : Hash + Eq {
     let min_size = size.start;
     HashSetStrategy(statics::Filter::new(
         statics::Map::new(vec(element, size), VecToHashSet),
-        "HashSet minimum size".to_owned(),
+        reject("HashSet minimum size"),
         MinSize(min_size)))
 }
 
@@ -224,7 +224,7 @@ where ValueFor<T> : Ord {
 
     BTreeSetStrategy(statics::Filter::new(
         statics::Map::new(vec(element, size), VecToBTreeSet),
-        "BTreeSet minimum size".to_owned(),
+        reject("BTreeSet minimum size"),
         MinSize(min_size)))
 }
 
@@ -275,7 +275,7 @@ where ValueFor<K> : Hash + Eq {
     let min_size = size.start;
     HashMapStrategy(statics::Filter::new(
         statics::Map::new(vec((key, value), size), VecToHashMap),
-        "HashMap minimum size".to_owned(),
+        reject("HashMap minimum size"),
         MinSize(min_size)))
 }
 
@@ -326,7 +326,7 @@ where ValueFor<K> : Ord {
     let min_size = size.start;
     BTreeMapStrategy(statics::Filter::new(
         statics::Map::new(vec((key, value), size.clone()), VecToBTreeMap),
-        "BTreeMap minimum size".to_owned(),
+        reject("BTreeMap minimum size"),
         MinSize(min_size)))
 }
 
@@ -349,8 +349,7 @@ pub struct VecValueTree<T : ValueTree> {
 impl<T : Strategy> Strategy for VecStrategy<T> {
     type Value = VecValueTree<T::Value>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let max_size = rand::distributions::Range::new(
             self.size.start, self.size.end).ind_sample(runner.rng());
         let mut elements = Vec::with_capacity(max_size);
@@ -471,7 +470,7 @@ mod test {
                 if v.iter().map(|&v| v).sum::<usize>() < 9 {
                     Ok(())
                 } else {
-                    Err(TestCaseError::Fail("greater than 8".to_owned()))
+                    Err(TestCaseError::Fail(reject("greater than 8")))
                 }
             });
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -470,7 +470,7 @@ mod test {
                 if v.iter().map(|&v| v).sum::<usize>() < 9 {
                     Ok(())
                 } else {
-                    Err(TestCaseError::Fail(reject("greater than 8")))
+                    Err(fail_case("greater than 8"))
                 }
             });
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -470,7 +470,7 @@ mod test {
                 if v.iter().map(|&v| v).sum::<usize>() < 9 {
                     Ok(())
                 } else {
-                    Err(fail_case("greater than 8"))
+                    fail_case("greater than 8")
                 }
             });
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -458,7 +458,7 @@ mod test {
         let mut num_successes = 0;
 
         for _ in 0..256 {
-            let mut runner = TestRunner::new(Config::default());
+            let mut runner = TestRunner::default();
             let case = input.new_value(&mut runner).unwrap();
             let start = case.current();
             // Has correct length
@@ -500,7 +500,7 @@ mod test {
     fn test_map() {
         // Only 8 possible keys
         let input = hash_map("[ab]{3}", "a", 2..3);
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
 
         for _ in 0..256 {
             let v = input.new_value(&mut runner).unwrap().current();
@@ -512,7 +512,7 @@ mod test {
     fn test_set() {
         // Only 8 possible values
         let input = hash_set("[ab]{3}", 2..3);
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
 
         for _ in 0..256 {
             let v = input.new_value(&mut runner).unwrap().current();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1415,8 +1415,7 @@ macro_rules! opaque_strategy_wrapper {
 
         impl $($sgen)* Strategy for $stratname $($sgen)* $($swhere)* {
             type Value = $stratvtty;
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<Self::Value, String> {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 self.0.new_value(runner).map($vtname)
             }
         }

--- a/src/num.rs
+++ b/src/num.rs
@@ -268,6 +268,11 @@ unsigned_integer_bin_search!(u32);
 unsigned_integer_bin_search!(u64);
 unsigned_integer_bin_search!(usize);
 
+#[cfg(feature = "unstable")]
+signed_integer_bin_search!(i128);
+#[cfg(feature = "unstable")]
+unsigned_integer_bin_search!(u128);
+
 macro_rules! float_bin_search {
     ($typ:ident) => {
         #[allow(missing_docs)]

--- a/src/num.rs
+++ b/src/num.rs
@@ -24,8 +24,7 @@ macro_rules! numeric_api {
         impl Strategy for Any {
             type Value = BinarySearch;
 
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<BinarySearch, String> {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new(runner.rng().gen()))
             }
         }
@@ -33,8 +32,7 @@ macro_rules! numeric_api {
         impl Strategy for Range<$typ> {
             type Value = BinarySearch;
 
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<BinarySearch, String> {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 let range = rand::distributions::Range::new(
                     self.start, self.end);
                 Ok(BinarySearch::new_clamped(
@@ -46,8 +44,7 @@ macro_rules! numeric_api {
         impl Strategy for RangeFrom<$typ> {
             type Value = BinarySearch;
 
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<BinarySearch, String> {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 // TODO `rand` has no way to express the inclusive-end range we
                 // need here.
                 let range = rand::distributions::Range::new(
@@ -61,8 +58,7 @@ macro_rules! numeric_api {
         impl Strategy for RangeTo<$typ> {
             type Value = BinarySearch;
 
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<BinarySearch, String> {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 let range = rand::distributions::Range::new(
                     ::std::$typ::MIN, self.end);
                 Ok(BinarySearch::new_clamped(

--- a/src/num.rs
+++ b/src/num.rs
@@ -453,7 +453,7 @@ mod test {
 
     #[test]
     fn signed_integer_range_including_zero_converges_to_zero() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..100 {
             let mut state = (-42i32..64i32).new_value(&mut runner).unwrap();
             let init_value = state.current();
@@ -470,7 +470,7 @@ mod test {
 
     #[test]
     fn negative_integer_range_stays_in_bounds() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..100 {
             let mut state = (..-42i32).new_value(&mut runner).unwrap();
             let init_value = state.current();
@@ -487,7 +487,7 @@ mod test {
 
     #[test]
     fn positive_signed_integer_range_stays_in_bounds() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..100 {
             let mut state = (42i32..).new_value(&mut runner).unwrap();
             let init_value = state.current();
@@ -504,7 +504,7 @@ mod test {
 
     #[test]
     fn unsigned_integer_range_stays_in_bounds() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..100 {
             let mut state = (42u32..56u32).new_value(&mut runner).unwrap();
             let init_value = state.current();
@@ -533,7 +533,7 @@ mod test {
 
     #[test]
     fn positive_float_simplifies_to_zero() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let mut value = (0.0f64..2.0).new_value(&mut runner).unwrap();
 
         while value.simplify() { }
@@ -543,7 +543,7 @@ mod test {
 
     #[test]
     fn positive_float_simplifies_to_base() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let mut value = (1.0f64..2.0).new_value(&mut runner).unwrap();
 
         while value.simplify() { }
@@ -553,7 +553,7 @@ mod test {
 
     #[test]
     fn negative_float_simplifies_to_zero() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let mut value = (-2.0f64..0.0).new_value(&mut runner).unwrap();
 
         while value.simplify() { }
@@ -563,7 +563,7 @@ mod test {
 
     #[test]
     fn positive_float_complicates_to_original() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let mut value = (1.0f64..2.0).new_value(&mut runner).unwrap();
         let orig = value.current();
 
@@ -611,7 +611,7 @@ mod test {
 
     #[test]
     fn float_simplifies_to_smallest_normal() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let mut value = (::std::f64::MIN_POSITIVE..2.0)
             .new_value(&mut runner).unwrap();
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -37,7 +37,7 @@ impl<T> fmt::Debug for NoneStrategy<T> {
 impl<T : fmt::Debug> Strategy for NoneStrategy<T> {
     type Value = Self;
 
-    fn new_value(&self, _: &mut TestRunner) -> Result<Self, String> {
+    fn new_value(&self, _: &mut TestRunner) -> NewTree<Self> {
         Ok(*self)
     }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -108,7 +108,7 @@ mod test {
     use super::*;
 
     fn count_some_of_1000(s: OptionStrategy<Just<i32>>) -> u32 {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let mut count = 0;
         for _ in 0..1000 {
             count += s.new_value(&mut runner).unwrap()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,6 +16,8 @@
 pub use strategy::{BoxedStrategy, Just, SBoxedStrategy, Strategy};
 pub use test_runner::Config as ProptestConfig;
 pub use test_runner::TestCaseError;
+pub use test_runner::fail_case;
+pub use test_runner::reject_case;
 
 /// Re-exports the entire public API of proptest so that an import of `prelude`
 /// allows simply writing, for example, `prop::num::i32::ANY` rather than

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,12 +12,19 @@
 //! This module is intended to be wildcard-imported, i.e.,
 //! `use proptest::prelude::*;`. Note that it re-exports the whole crate itself
 //! under the name `prop`, so you don't need a separate `use proptest;` line.
+//!
+//! In addition to Proptest's own APIs, this also reexports a small portion of
+//! the `rand` crate sufficient to easily use `prop_perturb` and other
+//! functionality that exposes random number generators. Please note that this
+//! is will always be a direct reexport; using these in preference to using the
+//! `rand` crate directly will not provide insulation from the upcoming
+//! revision to the `rand` crate.
 
 pub use strategy::{BoxedStrategy, Just, SBoxedStrategy, Strategy};
 pub use test_runner::Config as ProptestConfig;
 pub use test_runner::TestCaseError;
-pub use test_runner::fail_case;
-pub use test_runner::reject_case;
+
+pub use rand::{Rng, XorShiftRng};
 
 /// Re-exports the entire public API of proptest so that an import of `prelude`
 /// allows simply writing, for example, `prop::num::i32::ANY` rather than

--- a/src/result.rs
+++ b/src/result.rs
@@ -183,7 +183,7 @@ mod test {
 
     fn count_ok_of_1000<S : Strategy>(s: S) -> u32
     where S::Value : ValueTree<Value = Result<(), ()>> {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let mut count = 0;
         for _ in 0..1000 {
             count += s.new_value(&mut runner).unwrap()
@@ -222,7 +222,7 @@ mod test {
 
     #[test]
     fn shrink_to_correct_case() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         {
             let input = maybe_err(Just(()), Just(()));
             for _ in 0..64 {

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -70,8 +70,7 @@ pub struct Subsequence<T : Clone + 'static> {
 impl<T : fmt::Debug + Clone + 'static> Strategy for Subsequence<T> {
     type Value = SubsequenceValueTree<T>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         Ok(SubsequenceValueTree {
             values: Arc::clone(&self.values),
             inner: self.bit_strategy.new_value(runner)?,

--- a/src/strategy/filter.rs
+++ b/src/strategy/filter.rs
@@ -25,10 +25,7 @@ pub struct Filter<S, F> {
 
 impl<S, F> Filter<S, F> {
     pub (super) fn new(source: S, whence: Rejection, fun: F) -> Self {
-        // If whence was of the variant Rejection::BoxOwned we make it
-        // shared since it will be reused by both .clone() and by
-        // new_value() a lot of times.
-        let reusable = whence.for_reuse();
+        let reusable = whence.clone();
         Self { source: source, whence: reusable, fun: Arc::new(fun) }
     }
 }

--- a/src/strategy/filter.rs
+++ b/src/strategy/filter.rs
@@ -122,7 +122,7 @@ mod test {
         let input = (0..256).prop_filter("%3".to_owned(), |&v| 0 == v % 3);
 
         for _ in 0..256 {
-            let mut runner = TestRunner::new(Config::default());
+            let mut runner = TestRunner::default();
             let mut case = input.new_value(&mut runner).unwrap();
 
             assert!(0 == case.current() % 3);

--- a/src/strategy/flatten.rs
+++ b/src/strategy/flatten.rs
@@ -266,7 +266,7 @@ mod test {
                 if a <= 10000 || b <= a {
                     Ok(())
                 } else {
-                    fail_case("fail")
+                    Err(TestCaseError::fail("fail"))
                 }
             });
 
@@ -316,7 +316,7 @@ mod test {
             if pass.fetch_or(true, Ordering::SeqCst) {
                 Ok(())
             } else {
-                fail_case("fail")
+                Err(TestCaseError::fail("fail"))
             }
         });
     }

--- a/src/strategy/flatten.rs
+++ b/src/strategy/flatten.rs
@@ -260,7 +260,7 @@ mod test {
 
         let mut failures = 0;
         for _ in 0..1000 {
-            let mut runner = TestRunner::new(Config::default());
+            let mut runner = TestRunner::default();
             let case = input.new_value(&mut runner).unwrap();
             let result = runner.run_one(case, |&(a, b)| {
                 if a <= 10000 || b <= a {

--- a/src/strategy/flatten.rs
+++ b/src/strategy/flatten.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use strategy::fuse::Fuse;
 use strategy::traits::*;
+use strategy::Rejection;
 use test_runner::*;
 
 /// Adaptor that flattens a `Strategy` which produces other `Strategy`s into a
@@ -34,8 +35,7 @@ impl<S : Strategy> Strategy for Flatten<S>
 where ValueFor<S> : Strategy {
     type Value = FlattenValueTree<S::Value>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let meta = self.source.new_value(runner)?;
         FlattenValueTree::new(runner, meta)
     }
@@ -92,7 +92,7 @@ where S::Value : Strategy,
 }
 
 impl<S : ValueTree> FlattenValueTree<S> where S::Value : Strategy {
-    fn new(runner: &mut TestRunner, meta: S) -> Result<Self, String> {
+    fn new(runner: &mut TestRunner, meta: S) -> Result<Self, Rejection> {
         let current = meta.current().new_value(runner)?;
         Ok(FlattenValueTree {
             meta: Fuse::new(meta),
@@ -199,8 +199,7 @@ impl<S : Strategy> Strategy for IndFlatten<S>
 where ValueFor<S> : Strategy {
     type Value = <ValueFor<S> as Strategy>::Value;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let inner = self.0.new_value(runner)?;
         inner.current().new_value(runner)
     }
@@ -238,8 +237,7 @@ impl<S : Strategy, R : Strategy,
 Strategy for IndFlattenMap<S, F> {
     type Value = ::tuple::TupleValueTree<(S::Value, R::Value)>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let left = self.source.new_value(runner)?;
         let right_source = (self.fun)(left.current());
         let right = right_source.new_value(runner)?;
@@ -268,7 +266,7 @@ mod test {
                 if a <= 10000 || b <= a {
                     Ok(())
                 } else {
-                    Err(TestCaseError::Fail("fail".to_owned()))
+                    Err(TestCaseError::Fail("fail".into()))
                 }
             });
 
@@ -318,7 +316,7 @@ mod test {
             if pass.fetch_or(true, Ordering::SeqCst) {
                 Ok(())
             } else {
-                Err(TestCaseError::Fail("fail".to_owned()))
+                Err(TestCaseError::Fail("fail".into()))
             }
         });
     }

--- a/src/strategy/flatten.rs
+++ b/src/strategy/flatten.rs
@@ -266,7 +266,7 @@ mod test {
                 if a <= 10000 || b <= a {
                     Ok(())
                 } else {
-                    Err(fail_case("fail"))
+                    fail_case("fail")
                 }
             });
 
@@ -316,7 +316,7 @@ mod test {
             if pass.fetch_or(true, Ordering::SeqCst) {
                 Ok(())
             } else {
-                Err(fail_case("fail"))
+                fail_case("fail")
             }
         });
     }

--- a/src/strategy/flatten.rs
+++ b/src/strategy/flatten.rs
@@ -266,7 +266,7 @@ mod test {
                 if a <= 10000 || b <= a {
                     Ok(())
                 } else {
-                    Err(TestCaseError::Fail("fail".into()))
+                    Err(fail_case("fail"))
                 }
             });
 
@@ -316,7 +316,7 @@ mod test {
             if pass.fetch_or(true, Ordering::SeqCst) {
                 Ok(())
             } else {
-                Err(TestCaseError::Fail("fail".into()))
+                Err(fail_case("fail"))
             }
         });
     }

--- a/src/strategy/fuse.rs
+++ b/src/strategy/fuse.rs
@@ -58,8 +58,7 @@ impl<T> Fuse<T> {
 impl<T : Strategy> Strategy for Fuse<T> {
     type Value = Fuse<T::Value>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         self.inner.new_value(runner).map(Fuse::new)
     }
 }

--- a/src/strategy/map.rs
+++ b/src/strategy/map.rs
@@ -46,8 +46,7 @@ impl<S : Strategy, O : fmt::Debug,
 Strategy for Map<S, F> {
     type Value = Map<S::Value, F>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         self.source.new_value(runner).map(
             |v| Map { source: v, fun: Arc::clone(&self.fun) })
     }
@@ -101,8 +100,7 @@ impl<S : Strategy, O : fmt::Debug,
 Strategy for Perturb<S, F> {
     type Value = PerturbValueTree<S::Value, F>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let rng = XorShiftRng::from_seed(runner.rng().gen());
 
         self.source.new_value(runner).map(

--- a/src/strategy/map.rs
+++ b/src/strategy/map.rs
@@ -10,7 +10,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use rand::{Rng, SeedableRng, XorShiftRng};
+use rand::XorShiftRng;
 
 use strategy::traits::*;
 use test_runner::*;
@@ -101,7 +101,7 @@ Strategy for Perturb<S, F> {
     type Value = PerturbValueTree<S::Value, F>;
 
     fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        let rng = XorShiftRng::from_seed(runner.rng().gen());
+        let rng = runner.new_rng();
 
         self.source.new_value(runner).map(
             |v| PerturbValueTree {
@@ -161,6 +161,8 @@ ValueTree for PerturbValueTree<S, F> {
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;
+
+    use rand::Rng;
 
     use super::*;
 

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -9,6 +9,7 @@
 
 //! Defines the core traits used by Proptest.
 
+mod rejection;
 mod traits;
 mod map;
 mod filter;
@@ -18,6 +19,7 @@ mod recursive;
 mod shuffle;
 mod fuse;
 
+pub use self::rejection::*;
 pub use self::traits::*;
 pub use self::map::*;
 pub use self::filter::*;

--- a/src/strategy/recursive.rs
+++ b/src/strategy/recursive.rs
@@ -147,7 +147,7 @@ mod test {
                 .prop_map(Tree::Branch).boxed());
 
 
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..65536 {
             let tree = strat.new_value(&mut runner).unwrap().current();
             let (depth, count) = tree.stats();

--- a/src/strategy/recursive.rs
+++ b/src/strategy/recursive.rs
@@ -51,8 +51,7 @@ impl<T : fmt::Debug + 'static,
 Strategy for Recursive<BoxedStrategy<T>, F> {
     type Value = Box<ValueTree<Value = T>>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         // Since the generator is stateless, we can't implement any "absolutely
         // X many items" rule. We _can_, however, with extremely high
         // probability, obtain a value near what we want by using decaying

--- a/src/strategy/rejection.rs
+++ b/src/strategy/rejection.rs
@@ -1,3 +1,12 @@
+//-
+// Copyright 2017 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 //! Provides `Rejection`, a compact representation of why something, such
 //! as a generated value, was rejected.
 

--- a/src/strategy/rejection.rs
+++ b/src/strategy/rejection.rs
@@ -1,0 +1,185 @@
+//! Provides `Rejection`, a compact representation of why something, such
+//! as a generated value, was rejected.
+
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::rc::Rc;
+
+use self::Rejection::*;
+
+/// The reason for why something, such as a generated value, was rejected.
+///
+/// # Representation
+/// 
+/// This type is currently (representationally) equivalent to:
+///
+/// ```rust
+/// pub enum Rejection {
+///     Borrowed(&'static str),
+///     BoxOwned(Box<str>),
+///     RcOwned(Rc<str>),
+/// }
+///
+/// # fn main() {
+/// # use std::mem::size_of;
+/// assert_eq!(size_of::<Rejection>(), 3 * size_of::<usize>());
+/// # }
+/// ```
+///
+/// This is a compact and essentially copy-on-write representation while also
+/// allowing you not to allocate if the rejection message is not dynamic in
+/// nature. This is most efficient and should be used when possible. If you
+/// are allocating and then cloning the allocated `Rejection`, then you should
+/// prefer the `Rejection::RcOwned` variant as it will only bump the reference
+/// count and not actually do any new heap allocation.
+pub enum Rejection {
+    /// The borrowed representation - this is the most efficient if you for
+    /// example have a string in the data section of your program.
+    Borrowed(&'static str),
+    /// A reference counted shared string, use this if you have dynamically
+    /// generated content that is used more than once.
+    RcOwned(Rc<str>),
+    /// An owned boxed string, use this if you have a dynamicly generated
+    /// string that is only used once. If used more than once, instead use
+    /// `RcOwned`.
+    BoxOwned(Box<str>),
+}
+
+/// Constructs and returns a [`Rejection`] based on the input type.
+/// See the `From<T> for Rejection` implementations for details.
+///
+/// # Example
+///
+/// ```rust
+/// fn main() {
+///     use proptest::strategy::reject;
+///     let reason = format!("The value {:?} was too much!", 100);
+///     let reject = reject(reason);
+///     println!("{:?}", reject);
+/// }
+/// ```
+///
+/// [`Rejection`]: type.Rejection.html
+pub fn reject<S: Into<Rejection>>(string: S) -> Rejection {
+    string.into()
+}
+
+impl Rejection {
+    /// Converts this `Rejection` into either an owned one backed by `Rc`
+    /// or keeps the rejection as-is if it was in a borrowed form.
+    pub fn for_reuse(self) -> Self {
+        match self {
+            Borrowed(s) => Borrowed(s.into()),
+            BoxOwned(s) => RcOwned(s.into()),
+            RcOwned(s)  => RcOwned(s.clone()),
+        }
+    }
+
+    /// Converts this `Rejection` into an owned one backed by `Rc`.
+    pub fn to_shared(self) -> Self {
+        match self {
+            Borrowed(s) => RcOwned(s.into()),
+            BoxOwned(s) => RcOwned(s.into()),
+            RcOwned(s)  => RcOwned(s.clone()),
+        }
+    }
+
+    /// Converts this `Rejection` into an owned one backed by `Box`.
+    pub fn to_owned(self) -> Self {
+        match self {
+            Borrowed(s) => BoxOwned(s.into()),
+            BoxOwned(s) => BoxOwned(s),
+            RcOwned(s)  => BoxOwned((&*s).into()),
+        }
+    }
+}
+
+impl From<&'static str> for Rejection {
+    fn from(s: &'static str) -> Self {
+        Borrowed(s)
+    }
+}
+
+impl From<String> for Rejection {
+    fn from(s: String) -> Self {
+        BoxOwned(s.into())
+    }
+}
+
+impl From<Box<str>> for Rejection {
+    fn from(s: Box<str>) -> Self {
+        BoxOwned(s)
+    }
+}
+
+impl From<Rc<str>> for Rejection {
+    fn from(s: Rc<str>) -> Self {
+        RcOwned(s)
+    }
+}
+
+impl Deref for Rejection {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match *self {
+            Borrowed(s) => s,
+            BoxOwned(s) => &*s,
+            RcOwned(s)  => &*s,
+        }
+    }
+}
+
+impl Clone for Rejection {
+    fn clone(&self) -> Self {
+        match *self {
+            Borrowed(s) => Borrowed(s),
+            BoxOwned(s) => BoxOwned(s.clone()),
+            RcOwned(s)  => RcOwned(s.clone()),
+        }
+    }
+}
+
+impl fmt::Debug for Rejection {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&*self, f)
+    }
+}
+
+impl fmt::Display for Rejection {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&*self, f)
+    }
+}
+
+impl AsRef<str> for Rejection {
+    fn as_ref(&self) -> &str { &*self }
+}
+
+impl Borrow<str> for Rejection {
+    fn borrow(&self) -> &str { &*self }
+}
+
+impl<X: AsRef<str>> PartialEq<X> for Rejection {
+    fn eq(&self, rhs: &X) -> bool { self.as_ref() == rhs.as_ref() }
+}
+
+impl Eq for Rejection {}
+
+impl<X: AsRef<str>> PartialOrd<X> for Rejection {
+    fn partial_cmp(&self, rhs: &X) -> Option<Ordering> {
+        self.as_ref().partial_cmp(rhs.as_ref())
+    }
+}
+
+impl Ord for Rejection {
+    fn cmp(&self, rhs: &Self) -> Ordering { self.as_ref().cmp(rhs.as_ref()) }
+}
+
+impl Hash for Rejection {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (&*self).hash(state)
+    }
+}

--- a/src/strategy/rejection.rs
+++ b/src/strategy/rejection.rs
@@ -17,6 +17,8 @@ use self::Rejection::*;
 /// This type is currently (representationally) equivalent to:
 ///
 /// ```rust
+/// use std::rc::Rc;
+/// 
 /// pub enum Rejection {
 ///     Borrowed(&'static str),
 ///     BoxOwned(Box<str>),

--- a/src/strategy/rejection.rs
+++ b/src/strategy/rejection.rs
@@ -126,8 +126,8 @@ impl Deref for Rejection {
     fn deref(&self) -> &Self::Target {
         match *self {
             Borrowed(s) => s,
-            BoxOwned(s) => &*s,
-            RcOwned(s)  => &*s,
+            BoxOwned(ref s) => &*s,
+            RcOwned(ref s)  => &*s,
         }
     }
 }
@@ -135,22 +135,22 @@ impl Deref for Rejection {
 impl Clone for Rejection {
     fn clone(&self) -> Self {
         match *self {
-            Borrowed(s) => Borrowed(s),
-            BoxOwned(s) => BoxOwned(s.clone()),
-            RcOwned(s)  => RcOwned(s.clone()),
+            Borrowed(ref s) => Borrowed(s),
+            BoxOwned(ref s) => BoxOwned(s.clone()),
+            RcOwned(ref s)  => RcOwned(s.clone()),
         }
     }
 }
 
 impl fmt::Debug for Rejection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&*self, f)
+        fmt::Debug::fmt(self.as_ref(), f)
     }
 }
 
 impl fmt::Display for Rejection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&*self, f)
+        fmt::Display::fmt(self.as_ref(), f)
     }
 }
 
@@ -180,6 +180,6 @@ impl Ord for Rejection {
 
 impl Hash for Rejection {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        (&*self).hash(state)
+        self.as_ref().hash(state)
     }
 }

--- a/src/strategy/rejection.rs
+++ b/src/strategy/rejection.rs
@@ -7,57 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Provides `Rejection`, a compact representation of why something, such
+//! Provides `Rejection`, the reason why something, such
 //! as a generated value, was rejected.
 
 use std::borrow::Borrow;
-use std::cmp::Ordering;
 use std::fmt;
-use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-use std::rc::Rc;
-
-use self::Rejection::*;
+use std::borrow::Cow;
 
 /// The reason for why something, such as a generated value, was rejected.
-///
-/// # Representation
-/// 
-/// This type is currently representationally equivalent to:
-///
-/// ```rust
-/// use std::rc::Rc;
-/// 
-/// pub enum Rejection {
-///     Borrowed(&'static str),
-///     BoxOwned(Box<str>),
-///     RcOwned(Rc<str>),
-/// }
-///
-/// # fn main() {
-/// # use std::mem::size_of;
-/// assert_eq!(size_of::<Rejection>(), 3 * size_of::<usize>());
-/// # }
-/// ```
-///
-/// This is a compact and essentially copy-on-write representation while also
-/// allowing you not to allocate if the rejection message is not dynamic in
-/// nature. This is most efficient and should be used when possible. If you
-/// are allocating and then cloning the allocated `Rejection`, then you should
-/// prefer the `Rejection::RcOwned` variant as it will only bump the reference
-/// count and not actually do any new heap allocation.
-pub enum Rejection {
-    /// The borrowed representation - this is the most efficient if you for
-    /// example have a string in the data section of your program.
-    Borrowed(&'static str),
-    /// A reference counted shared string, use this if you have dynamically
-    /// generated content that is used more than once.
-    RcOwned(Rc<str>),
-    /// An owned boxed string, use this if you have a dynamicly generated
-    /// string that is only used once. If used more than once, instead use
-    /// `RcOwned`.
-    BoxOwned(Box<str>),
-}
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Rejection(Cow<'static, str>);
 
 /// Constructs and returns a [`Rejection`] based on the input type.
 /// See the `From<T> for Rejection` implementations for details.
@@ -74,95 +34,31 @@ pub enum Rejection {
 /// ```
 ///
 /// [`Rejection`]: enum.Rejection.html
-pub fn reject<S: Into<Rejection>>(string: S) -> Rejection {
-    string.into()
-}
-
-impl Rejection {
-    /// Converts this `Rejection` into either an owned one backed by `Rc`
-    /// or keeps the rejection as-is if it was in a borrowed form.
-    pub fn for_reuse(self) -> Self {
-        match self {
-            Borrowed(s) => Borrowed(s.into()),
-            BoxOwned(s) => RcOwned(s.into()),
-            RcOwned(s)  => RcOwned(s.clone()),
-        }
-    }
-
-    /// Converts this `Rejection` into an owned one backed by `Rc`.
-    pub fn to_shared(self) -> Self {
-        match self {
-            Borrowed(s) => RcOwned(s.into()),
-            BoxOwned(s) => RcOwned(s.into()),
-            RcOwned(s)  => RcOwned(s.clone()),
-        }
-    }
-
-    /// Converts this `Rejection` into an owned one backed by `Box`.
-    pub fn to_owned(self) -> Self {
-        match self {
-            Borrowed(s) => BoxOwned(s.into()),
-            BoxOwned(s) => BoxOwned(s),
-            RcOwned(s)  => BoxOwned((&*s).into()),
-        }
-    }
+pub fn reject<S: Into<Rejection>>(reason: S) -> Rejection {
+    reason.into()
 }
 
 impl From<&'static str> for Rejection {
     fn from(s: &'static str) -> Self {
-        Borrowed(s)
+        Rejection(s.into())
     }
 }
 
 impl From<String> for Rejection {
     fn from(s: String) -> Self {
-        BoxOwned(s.into())
+        Rejection(s.into())
     }
 }
 
 impl From<Box<str>> for Rejection {
     fn from(s: Box<str>) -> Self {
-        BoxOwned(s)
-    }
-}
-
-impl From<Rc<str>> for Rejection {
-    fn from(s: Rc<str>) -> Self {
-        RcOwned(s)
+        Rejection(String::from(s).into())
     }
 }
 
 impl Deref for Rejection {
     type Target = str;
-    fn deref(&self) -> &Self::Target {
-        match *self {
-            Borrowed(s) => s,
-            BoxOwned(ref s) => &*s,
-            RcOwned(ref s)  => &*s,
-        }
-    }
-}
-
-impl Clone for Rejection {
-    fn clone(&self) -> Self {
-        match *self {
-            Borrowed(ref s) => Borrowed(s),
-            BoxOwned(ref s) => BoxOwned(s.clone()),
-            RcOwned(ref s)  => RcOwned(s.clone()),
-        }
-    }
-}
-
-impl fmt::Debug for Rejection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self.as_ref(), f)
-    }
-}
-
-impl fmt::Display for Rejection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self.as_ref(), f)
-    }
+    fn deref(&self) -> &Self::Target { self.0.deref() }
 }
 
 impl AsRef<str> for Rejection {
@@ -173,24 +69,8 @@ impl Borrow<str> for Rejection {
     fn borrow(&self) -> &str { &*self }
 }
 
-impl<X: AsRef<str>> PartialEq<X> for Rejection {
-    fn eq(&self, rhs: &X) -> bool { self.as_ref() == rhs.as_ref() }
-}
-
-impl Eq for Rejection {}
-
-impl<X: AsRef<str>> PartialOrd<X> for Rejection {
-    fn partial_cmp(&self, rhs: &X) -> Option<Ordering> {
-        self.as_ref().partial_cmp(rhs.as_ref())
-    }
-}
-
-impl Ord for Rejection {
-    fn cmp(&self, rhs: &Self) -> Ordering { self.as_ref().cmp(rhs.as_ref()) }
-}
-
-impl Hash for Rejection {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state)
+impl fmt::Display for Rejection {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.as_ref(), f)
     }
 }

--- a/src/strategy/rejection.rs
+++ b/src/strategy/rejection.rs
@@ -14,7 +14,7 @@ use self::Rejection::*;
 ///
 /// # Representation
 /// 
-/// This type is currently (representationally) equivalent to:
+/// This type is currently representationally equivalent to:
 ///
 /// ```rust
 /// use std::rc::Rc;
@@ -64,7 +64,7 @@ pub enum Rejection {
 /// }
 /// ```
 ///
-/// [`Rejection`]: type.Rejection.html
+/// [`Rejection`]: enum.Rejection.html
 pub fn reject<S: Into<Rejection>>(string: S) -> Rejection {
     string.into()
 }

--- a/src/strategy/shuffle.rs
+++ b/src/strategy/shuffle.rs
@@ -91,8 +91,7 @@ impl<S : Strategy> Strategy for Shuffle<S>
 where ValueFor<S> : Shuffleable {
     type Value = ShuffleValueTree<S::Value>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let rng = XorShiftRng::from_seed(runner.rng().gen());
 
         self.0.new_value(runner).map(|inner| ShuffleValueTree {

--- a/src/strategy/shuffle.rs
+++ b/src/strategy/shuffle.rs
@@ -10,7 +10,7 @@
 use std::cell::Cell;
 use std::collections::VecDeque;
 
-use rand::{Rng, SeedableRng, XorShiftRng};
+use rand::{Rng, XorShiftRng};
 
 use num;
 use strategy::traits::*;
@@ -92,7 +92,7 @@ where ValueFor<S> : Shuffleable {
     type Value = ShuffleValueTree<S::Value>;
 
     fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        let rng = XorShiftRng::from_seed(runner.rng().gen());
+        let rng = runner.new_rng();
 
         self.0.new_value(runner).map(|inner| ShuffleValueTree {
             inner, rng,

--- a/src/strategy/statics.rs
+++ b/src/strategy/statics.rs
@@ -50,7 +50,7 @@ impl<S, F> Filter<S, F> {
     pub fn new(source: S, whence: Rejection, filter: F) -> Self {
         // NOTE: We don't use universal quantification R: Into<Rejection>
         // since the module is not conviniently exposed.
-        Filter { source, whence: whence.for_reuse(), fun: filter }
+        Filter { source, whence: whence.clone(), fun: filter }
     }
 }
 

--- a/src/strategy/statics.rs
+++ b/src/strategy/statics.rs
@@ -27,6 +27,7 @@
 use std::fmt;
 
 use strategy::traits::*;
+use strategy::Rejection;
 use test_runner::*;
 
 /// Essentially `Fn (&T) -> bool`.
@@ -39,15 +40,17 @@ pub trait FilterFn<T> {
 #[derive(Clone)]
 pub struct Filter<S, F> {
     source: S,
-    whence: String,
+    whence: Rejection,
     fun: F,
 }
 
 impl<S, F> Filter<S, F> {
     /// Adapt strategy `source` to reject values which do not pass `filter`,
     /// using `whence` as the reported reason/location.
-    pub fn new(source: S, whence: String, filter: F) -> Self {
-        Filter { source, whence, fun: filter }
+    pub fn new(source: S, whence: Rejection, filter: F) -> Self {
+        // NOTE: We don't use universal quantification R: Into<Rejection>
+        // since the module is not conviniently exposed.
+        Filter { source, whence: whence.for_reuse(), fun: filter }
     }
 }
 
@@ -66,8 +69,7 @@ impl<S : Strategy,
 Strategy for Filter<S, F> {
     type Value = Filter<S::Value, F>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         loop {
             let val = self.source.new_value(runner)?;
             if !self.fun.apply(&val.current()) {
@@ -157,8 +159,7 @@ impl<S : Strategy,
 Strategy for Map<S, F> {
     type Value = Map<S::Value, F>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         self.source.new_value(runner).map(
             |v| Map { source: v, fun: self.fun.clone() })
     }
@@ -193,7 +194,7 @@ mod test {
             fn apply(&self, &v: &i32) -> bool { 0 == v % 3 }
         }
 
-        let input = Filter::new((0..256), "%3".to_owned(), MyFilter);
+        let input = Filter::new((0..256), "%3".into(), MyFilter);
 
         for _ in 0..256 {
             let mut runner = TestRunner::new(Config::default());

--- a/src/strategy/statics.rs
+++ b/src/strategy/statics.rs
@@ -197,7 +197,7 @@ mod test {
         let input = Filter::new((0..256), "%3".into(), MyFilter);
 
         for _ in 0..256 {
-            let mut runner = TestRunner::new(Config::default());
+            let mut runner = TestRunner::default();
             let mut case = input.new_value(&mut runner).unwrap();
 
             assert!(0 == case.current() % 3);
@@ -220,7 +220,7 @@ mod test {
 
         let input = Map::new((0..10), MyMap);
 
-        TestRunner::new(Config::default())
+        TestRunner::default()
             .run(&input, |&v| {
                 assert!(0 == v % 2);
                 Ok(())

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -612,7 +612,7 @@ pub fn check_strategy_sanity<S : Strategy>(
     strategy: S, options: Option<CheckStrategySanityOptions>)
 where S::Value : Clone + fmt::Debug, ValueFor<S> : cmp::PartialEq {
     let options = options.unwrap_or_else(CheckStrategySanityOptions::default);
-    let mut runner = TestRunner::new(Config::default());
+    let mut runner = TestRunner::default();
 
     for _ in 0..1024 {
         let mut gen_tries = 0;

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -16,6 +16,17 @@ use rand::XorShiftRng;
 use strategy::*;
 use test_runner::*;
 
+/// A new [`ValueTree`] from a [`Strategy`] when [`Ok`] or otherwise [`Err`]
+/// when a new value-tree can not be produced for some reason such as
+/// in the case of filtering with a predicate which always returns false.
+/// You should pass in your strategy as the type parameter.
+///
+/// [`Strategy`]: trait.Strategy.html
+/// [`ValueTree`]: trait.ValueTree.html
+/// [`Ok`]: https://doc.rust-lang.org/nightly/std/result/enum.Result.html#variant.Ok
+/// [`Err`]: https://doc.rust-lang.org/nightly/std/result/enum.Result.html#variant.Err
+pub type NewTree<S> = Result<<S as Strategy>::Value, Rejection>;
+
 /// The value that functions under test use for a particular `Strategy`.
 pub type ValueFor<S> = <<S as Strategy>::Value as ValueTree>::Value;
 
@@ -36,9 +47,7 @@ pub trait Strategy : fmt::Debug {
     /// This may fail if there are constraints on the generated value and the
     /// generator is unable to produce anything that satisfies them. Any
     /// failure is wrapped in `TestError::Abort`.
-    fn new_value
-        (&self, runner: &mut TestRunner)
-         -> Result<Self::Value, String>;
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self>;
 
     /// Returns a strategy which produces values transformed by the function
     /// `fun`.
@@ -220,10 +229,10 @@ pub trait Strategy : fmt::Debug {
     /// whole-input rejections.
     ///
     /// `whence` is used to record where and why the rejection occurred.
-    fn prop_filter<F : Fn (&ValueFor<Self>) -> bool>
-        (self, whence: String, fun: F) -> Filter<Self, F>
+    fn prop_filter<R: Into<Rejection>, F : Fn (&ValueFor<Self>) -> bool>
+        (self, whence: R, fun: F) -> Filter<Self, F>
     where Self : Sized {
-        Filter { source: self, whence: whence, fun: Arc::new(fun) }
+        Filter::new(self, whence.into(), fun)
     }
 
     /// Returns a strategy which picks uniformly from `self` and `other`.
@@ -404,9 +413,9 @@ macro_rules! proxy_strategy {
         impl<$($lt,)* S : Strategy + ?Sized> Strategy for $typ {
             type Value = S::Value;
 
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<Self::Value, String>
-            { (**self).new_value(runner) }
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                (**self).new_value(runner)
+            }
         }
     };
 }
@@ -499,9 +508,7 @@ impl<T : Strategy> Strategy for BoxedStrategyWrapper<T>
 where T::Value : 'static {
     type Value = Box<ValueTree<Value = ValueFor<T>>>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-        -> Result<Self::Value, String>
-    {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         Ok(Box::new(self.0.new_value(runner)?))
     }
 }
@@ -520,7 +527,7 @@ pub use self::Just as Singleton;
 impl<T : Clone + fmt::Debug> Strategy for Just<T> {
     type Value = Self;
 
-    fn new_value(&self, _: &mut TestRunner) -> Result<Self::Value, String> {
+    fn new_value(&self, _: &mut TestRunner) -> NewTree<Self> {
         Ok(self.clone())
     }
 }
@@ -546,8 +553,7 @@ pub struct NoShrink<T>(T);
 impl<T : Strategy> Strategy for NoShrink<T> {
     type Value = NoShrink<T::Value>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         self.0.new_value(runner).map(NoShrink)
     }
 }

--- a/src/strategy/unions.rs
+++ b/src/strategy/unions.rs
@@ -346,7 +346,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                fail_case("fail")
+                Err(TestCaseError::fail("fail"))
             });
 
             match result {
@@ -413,7 +413,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                fail_case("fail")
+                Err(TestCaseError::fail("fail"))
             });
 
             match result {

--- a/src/strategy/unions.rs
+++ b/src/strategy/unions.rs
@@ -346,7 +346,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                Err(fail_case("fail"))
+                fail_case("fail")
             });
 
             match result {
@@ -413,7 +413,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                Err(fail_case("fail"))
+                fail_case("fail")
             });
 
             match result {

--- a/src/strategy/unions.rs
+++ b/src/strategy/unions.rs
@@ -341,7 +341,7 @@ mod test {
         let mut converged_low = 0;
         let mut converged_high = 0;
         for _ in 0..256 {
-            let mut runner = TestRunner::new(Config::default());
+            let mut runner = TestRunner::default();
             let case = input.new_value(&mut runner).unwrap();
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
@@ -374,7 +374,7 @@ mod test {
         ]);
 
         let mut counts = [0, 0, 0];
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..65536 {
             counts[input.new_value(&mut runner).unwrap().current()] += 1;
         }
@@ -408,7 +408,7 @@ mod test {
         let mut converged_low = 0;
         let mut converged_high = 0;
         for _ in 0..256 {
-            let mut runner = TestRunner::new(Config::default());
+            let mut runner = TestRunner::default();
             let case = input.new_value(&mut runner).unwrap();
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
@@ -441,7 +441,7 @@ mod test {
         ));
 
         let mut counts = [0, 0, 0];
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         for _ in 0..65536 {
             counts[input.new_value(&mut runner).unwrap().current()] += 1;
         }
@@ -455,7 +455,7 @@ mod test {
 
     #[test]
     fn test_tuple_union_all_sizes() {
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
         let r = 1i32..10;
 
         macro_rules! test {

--- a/src/strategy/unions.rs
+++ b/src/strategy/unions.rs
@@ -89,8 +89,7 @@ fn pick_weighted<I : Iterator<Item = u32>>(runner: &mut TestRunner,
 impl<T : Strategy> Strategy for Union<T> {
     type Value = UnionValueTree<T::Value>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         fn extract_weight<V>(&(w, _): &W<V>) -> u32 { w }
 
         let pick = pick_weighted(
@@ -240,8 +239,7 @@ macro_rules! tuple_union {
             type Value = TupleUnionValueTree<
                 (A::Value, $(Option<$gen::Value>),*)>;
 
-            fn new_value(&self, runner: &mut TestRunner)
-                         -> Result<Self::Value, String> {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 let weights = [((self.0).0).0, $(((self.0).$ix).0),*];
                 let pick = pick_weighted(runner, weights.iter().cloned(),
                                          weights.iter().cloned());
@@ -348,7 +346,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                Err(TestCaseError::Fail("fail".to_owned()))
+                Err(TestCaseError::Fail("fail".into()))
             });
 
             match result {
@@ -415,7 +413,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                Err(TestCaseError::Fail("fail".to_owned()))
+                Err(TestCaseError::Fail("fail".into()))
             });
 
             match result {

--- a/src/strategy/unions.rs
+++ b/src/strategy/unions.rs
@@ -346,7 +346,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                Err(TestCaseError::Fail("fail".into()))
+                Err(fail_case("fail"))
             });
 
             match result {
@@ -413,7 +413,7 @@ mod test {
             let result = runner.run_one(case, |&v| if v < 15 {
                 Ok(())
             } else {
-                Err(TestCaseError::Fail("fail".into()))
+                Err(fail_case("fail"))
             });
 
             match result {

--- a/src/string.rs
+++ b/src/string.rs
@@ -60,8 +60,7 @@ opaque_strategy_wrapper! {
 impl Strategy for str {
     type Value = RegexGeneratorValueTree<String>;
 
-    fn new_value(&self, runner: &mut TestRunner)
-                 -> Result<Self::Value, String> {
+    fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
         string_regex(self).unwrap().new_value(runner)
     }
 }

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -82,6 +82,7 @@ macro_rules! proptest {
             fn $test_name() {
                 let mut runner = $crate::test_runner::TestRunner::new(
                     $config.clone());
+                runner.set_source_file(::std::path::Path::new(file!()));
                 let names = proptest_helper!(@_WRAPSTR ($($parm),*));
                 match runner.run(
                     &$crate::strategy::Strategy::prop_map(
@@ -129,10 +130,10 @@ macro_rules! prop_assume {
 
     ($expr:expr, $fmt:tt $(, $fmt_arg:expr),*) => {
         if !$expr {
-            return $crate::test_runner::reject_case(
+            return Err($crate::test_runner::TestCaseError::reject(
                 format!(concat!("{}:{}:{}: ", $fmt),
                         file!(), line!(), column!()
-                        $(, $fmt_arg)*));
+                        $(, $fmt_arg)*)));
         }
     };
 }
@@ -517,7 +518,7 @@ macro_rules! prop_assert {
         if !$cond {
             let message = format!($($fmt)*);
             let message = format!("{} at {}:{}", message, file!(), line!());
-            return $crate::test_runner::fail_case(message);
+            return Err($crate::test_runner::TestCaseError::fail(message));
         }
     };
 }

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -129,10 +129,10 @@ macro_rules! prop_assume {
 
     ($expr:expr, $fmt:tt $(, $fmt_arg:expr),*) => {
         if !$expr {
-            return Err($crate::test_runner::reject_case(
+            return $crate::test_runner::reject_case(
                 format!(concat!("{}:{}:{}: ", $fmt),
                         file!(), line!(), column!()
-                        $(, $fmt_arg)*)));
+                        $(, $fmt_arg)*));
         }
     };
 }
@@ -517,7 +517,7 @@ macro_rules! prop_assert {
         if !$cond {
             let message = format!($($fmt)*);
             let message = format!("{} at {}:{}", message, file!(), line!());
-            return Err($crate::test_runner::fail_case(message));
+            return $crate::test_runner::fail_case(message);
         }
     };
 }

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -129,11 +129,10 @@ macro_rules! prop_assume {
 
     ($expr:expr, $fmt:tt $(, $fmt_arg:expr),*) => {
         if !$expr {
-            return Err($crate::test_runner::TestCaseError::Reject(
-                $crate::strategy::reject(
+            return Err($crate::test_runner::reject_case(
                 format!(concat!("{}:{}:{}: ", $fmt),
                         file!(), line!(), column!()
-                        $(, $fmt_arg)*))));
+                        $(, $fmt_arg)*)));
         }
     };
 }
@@ -518,8 +517,7 @@ macro_rules! prop_assert {
         if !$cond {
             let message = format!($($fmt)*);
             let message = format!("{} at {}:{}", message, file!(), line!());
-            return Err($crate::test_runner::TestCaseError::Fail(
-                $crate::strategy::reject(message)));
+            return Err($crate::test_runner::fail_case(message));
         }
     };
 }

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -911,7 +911,7 @@ mod test {
             use strategy::*;
             use test_runner::*;
 
-            let mut runner = TestRunner::new(Config::default());
+            let mut runner = TestRunner::default();
             let mut seen = HashSet::new();
             for _ in 0..1024 {
                 seen.insert(s.new_value(&mut runner).unwrap().current());

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -130,9 +130,10 @@ macro_rules! prop_assume {
     ($expr:expr, $fmt:tt $(, $fmt_arg:expr),*) => {
         if !$expr {
             return Err($crate::test_runner::TestCaseError::Reject(
+                $crate::strategy::reject(
                 format!(concat!("{}:{}:{}: ", $fmt),
                         file!(), line!(), column!()
-                        $(, $fmt_arg)*)));
+                        $(, $fmt_arg)*))));
         }
     };
 }
@@ -517,7 +518,8 @@ macro_rules! prop_assert {
         if !$cond {
             let message = format!($($fmt)*);
             let message = format!("{} at {}:{}", message, file!(), line!());
-            return Err($crate::test_runner::TestCaseError::Fail(message));
+            return Err($crate::test_runner::TestCaseError::Fail(
+                $crate::strategy::reject(message)));
         }
     };
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017 Jason Lingle
+// Copyright 2017, 2018 Jason Lingle
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -12,16 +12,20 @@
 //! You do not normally need to access things in this module directly except
 //! when implementing new low-level strategies.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
+use std::fs;
+use std::io::{self, BufRead, Write};
 use std::panic::{self, AssertUnwindSafe};
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 
-use rand::{self, XorShiftRng};
+use rand::{self, Rand, SeedableRng, XorShiftRng};
 
 use strategy::*;
 
@@ -34,6 +38,7 @@ lazy_static! {
             max_local_rejects: 65536,
             max_global_rejects: 1024,
             max_flat_map_regens: 1_000_000,
+            failure_persistence: FailurePersistence::default(),
             _non_exhaustive: (),
         };
 
@@ -85,6 +90,8 @@ pub struct Config {
     /// The number of successful test cases that must execute for the test as a
     /// whole to pass.
     ///
+    /// This does not include implicitly-replayed persisted failing cases.
+    ///
     /// The default is 256, which can be overridden by setting the
     /// `PROPTEST_CASES` environment variable.
     pub cases: u32,
@@ -107,6 +114,15 @@ pub struct Config {
     /// The default is 1_000_000, which can be overridden by setting the
     /// `PROPTEST_MAX_FLAT_MAP_REGENS` environment variable.
     pub max_flat_map_regens: u32,
+    /// Indicates how to determine the file to use for persisting failed test
+    /// results.
+    ///
+    /// See the docs of [`FailurePersistence`](enum.FailurePersistence.html)
+    /// for more information.
+    ///
+    /// The default is `FailurePersistence::SourceParallel("proptest-regressions")`.
+    /// The default cannot currently be overridden by an environment variable.
+    pub failure_persistence: FailurePersistence,
     // Needs to be public so FRU syntax can be used.
     #[doc(hidden)]
     pub _non_exhaustive: (),
@@ -137,6 +153,134 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         DEFAULT_CONFIG.clone()
+    }
+}
+
+/// Describes how failing test cases are persisted.
+///
+/// Note that file names in this enum are `&str` rather than `&Path` since
+/// constant functions are not yet in Rust stable as of 2017-12-16.
+///
+/// In all cases, if a derived path references a directory which does not yet
+/// exist, proptest will attempt to create all necessary parent directories.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FailurePersistence {
+    /// Completely disables persistence of failing test cases.
+    ///
+    /// This is semantically equivalent to `Direct("/dev/null")` on Unix and
+    /// `Direct("NUL")` on Windows (though it is internally handled by simply
+    /// not doing any I/O).
+    Off,
+    /// The path given to `TestRunner::set_source_file()` is parsed. The path
+    /// is traversed up the directory tree until a directory containing a file
+    /// named `lib.rs` or `main.rs` is found. A sibling to that directory with
+    /// the name given by the string in this configuration is created, and a
+    /// file with the same name and path relative to the source directory, but
+    /// with the extension changed to `.txt`, is used.
+    ///
+    /// For example, given a source path of
+    /// `/home/jsmith/code/project/src/foo/bar.rs` and a configuration of
+    /// `SourceParallel("proptest-regressions")` (the default), assuming the
+    /// `src` directory has a `lib.rs` or `main.rs`, the resulting file would
+    /// be `/home/jsmith/code/project/proptest-regressions/foo/bar.txt`.
+    ///
+    /// If no `lib.rs` or `main.rs` can be found, a warning is printed and this
+    /// behaves like `WithSource`.
+    ///
+    /// If no source file has been configured, a warning is printed and this
+    /// behaves like `Off`.
+    SourceParallel(&'static str),
+    /// The path given to `TestRunner::set_source_file()` is parsed. The
+    /// extension of the path is changed to the string given in this
+    /// configuration, and that filename is used.
+    ///
+    /// For example, given a source path of
+    /// `/home/jsmith/code/project/src/foo/bar.rs` and a configuration of
+    /// `WithSource("regressions")`, the resulting path would be
+    /// `/home/jsmith/code/project/src/foo/bar.regressions`.
+    WithSource(&'static str),
+    /// The string given in this option is directly used as a file path without
+    /// any further processing.
+    Direct(&'static str),
+    #[doc(hidden)]
+    #[allow(missing_docs)]
+    _NonExhaustive,
+}
+
+impl Default for FailurePersistence {
+    fn default() -> Self {
+        FailurePersistence::SourceParallel("proptest-regressions")
+    }
+}
+
+impl FailurePersistence {
+    /// Given the nominal source path, determine the location of the failure
+    /// persistence file, if any.
+    fn resolve(&self, source: Option<&Path>) -> Option<PathBuf> {
+        match *self {
+            FailurePersistence::Off => None,
+
+            FailurePersistence::SourceParallel(sibling) => match source {
+                Some(source_path) => {
+                    let mut dir = source_path.to_owned();
+                    let mut found = false;
+                    while dir.pop() {
+                        if dir.join("lib.rs").is_file() ||
+                            dir.join("main.rs").is_file()
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if !found {
+                        eprintln!(
+                            "proptest: FailurePersistence::SourceParallel set, \
+                             but failed to find lib.rs or main.rs");
+                        FailurePersistence::WithSource(sibling).resolve(source)
+                    } else {
+                        let suffix = source_path.strip_prefix(&dir)
+                            .expect("parent of source is not a prefix of it?")
+                            .to_owned();
+                        let mut result = dir;
+                        // If we've somehow reached the root, or someone gave
+                        // us a relative path that we've exhausted, just accept
+                        // creating a subdirectory instead.
+                        let _ = result.pop();
+                        result.push(sibling);
+                        result.push(&suffix);
+                        result.set_extension("txt");
+                        Some(result)
+                    }
+                },
+                None => {
+                    eprintln!(
+                        "proptest: FailurePersistence::SourceParallel set, \
+                         but no source file known");
+                    None
+                },
+            },
+
+            FailurePersistence::WithSource(extension) => match source {
+                Some(source_path) => {
+                    let mut result = source_path.to_owned();
+                    result.set_extension(extension);
+                    Some(result)
+                },
+
+                None => {
+                    eprintln!("proptest: FailurePersistence::WithSource set, \
+                               but no source file known");
+                    None
+                },
+            },
+
+            FailurePersistence::Direct(path) =>
+                Some(Path::new(path).to_owned()),
+
+            FailurePersistence::_NonExhaustive =>
+                panic!("FailurePersistence set to _NonExhaustive"),
+        }
     }
 }
 
@@ -186,16 +330,6 @@ impl TestCaseError {
     pub fn fail<R: Into<Rejection>>(reason: R) -> Self {
         TestCaseError::Fail(reason.into())
     }
-}
-
-/// Short-hand for `Err(TestCaseError::reject(..))`.
-pub fn reject_case<R: Into<Rejection>>(reason: R) -> TestCaseResult {
-    Err(TestCaseError::reject(reason))
-}
-
-/// Short-hand for `Err(TestCaseError::fail(..))`.
-pub fn fail_case<R: Into<Rejection>>(reason: R) -> TestCaseResult {
-    Err(TestCaseError::fail(reason))
 }
 
 impl fmt::Display for TestCaseError {
@@ -259,9 +393,9 @@ pub struct TestRunner {
     global_rejects: u32,
     rng: XorShiftRng,
     flat_map_regens: Arc<AtomicUsize>,
-
     local_reject_detail: RejectionDetail,
     global_reject_detail: RejectionDetail,
+    source_file: Option<Cow<'static, Path>>,
 }
 
 impl fmt::Debug for TestRunner {
@@ -275,6 +409,7 @@ impl fmt::Debug for TestRunner {
             .field("flat_map_regens", &self.flat_map_regens)
             .field("local_reject_detail", &self.local_reject_detail)
             .field("global_reject_detail", &self.global_reject_detail)
+            .field("source_file", &self.source_file)
             .finish()
     }
 }
@@ -303,17 +438,137 @@ impl Default for TestRunner {
     }
 }
 
+lazy_static! {
+    /// Used to guard access to the persistence file(s) so that a single
+    /// process will not step on its own toes.
+    ///
+    /// We don't have much protecting us should two separate process try to
+    /// write to the same file at once (depending on how atomic append mode is
+    /// on the OS), but this should be extremely rare.
+    static ref PERSISTENCE_LOCK: RwLock<()> = RwLock::new(());
+}
+
+fn load_persisted_failures(path: Option<&PathBuf>) -> Vec<[u32;4]> {
+    let result: io::Result<Vec<[u32;4]>> =
+        path.map_or_else(|| Ok(vec![]), |path| {
+            // .ok() instead of .unwrap() so we don't propagate panics here
+            let _lock = PERSISTENCE_LOCK.read().ok();
+
+            let mut ret = Vec::new();
+
+            let input = io::BufReader::new(fs::File::open(path)?);
+            for (lineno, line) in input.lines().enumerate() {
+                let mut line = line?;
+                if let Some(comment_start) = line.find('#') {
+                    line.truncate(comment_start);
+                }
+
+                let parts = line.trim().split(' ').collect::<Vec<_>>();
+                if 5 == parts.len() && "xs" == parts[0] {
+                    let seed = parts[1].parse::<u32>().and_then(
+                        |a| parts[2].parse::<u32>().and_then(
+                            |b| parts[3].parse::<u32>().and_then(
+                                |c| parts[4].parse::<u32>().map(
+                                    |d| [a, b, c, d]))));
+                    if let Ok(seed) = seed {
+                        ret.push(seed);
+                    } else {
+                        eprintln!(
+                            "proptest: {}:{}: unparsable line, \
+                             ignoring", path.display(), lineno + 1);
+                    }
+                } else if parts.len() > 1 {
+                    eprintln!("proptest: {}:{}: unknown case type `{}` \
+                               (corrupt file or newer proptest version?)",
+                              path.display(), lineno + 1, parts[0]);
+                }
+            }
+
+            Ok(ret)
+        });
+
+    match result {
+        Ok(r) => r,
+        Err(err) => {
+            if io::ErrorKind::NotFound != err.kind() {
+                eprintln!(
+                    "proptest: failed to open {}: {}",
+                    path.map(|x| &**x).unwrap_or(Path::new("??")).display(),
+                    err);
+            }
+            vec![]
+        },
+    }
+}
+
+fn save_persisted_failure(path: Option<&PathBuf>,
+                          seed: [u32;4],
+                          value: &fmt::Debug) {
+    if let Some(path) = path {
+        // .ok() instead of .unwrap() so we don't propagate panics here
+        let _lock = PERSISTENCE_LOCK.write().ok();
+        let is_new = !path.is_file();
+
+        let mut to_write = Vec::<u8>::new();
+        if is_new {
+            writeln!(to_write, "\
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.")
+                    .expect("writeln! to vec failed");
+        }
+        let mut data_line = Vec::<u8>::new();
+        write!(data_line, "xs {} {} {} {} # shrinks to {:?}",
+               seed[0], seed[1], seed[2], seed[3],
+               value).expect("write! to vec failed");
+        // Ensure there are no newlines in the debug output
+        for byte in &mut data_line {
+            if b'\n' == *byte || b'\r' == *byte {
+                *byte = b' ';
+            }
+        }
+        to_write.extend(data_line);
+        to_write.push(b'\n');
+
+        fn do_write(dst: &Path, data: &[u8]) -> io::Result<()> {
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            let mut options = fs::OpenOptions::new();
+            options.append(true).create(true);
+            let mut out = options.open(dst)?;
+            out.write_all(data)?;
+
+            Ok(())
+        }
+
+        if let Err(e) = do_write(path, &to_write) {
+            eprintln!(
+                "proptest: failed to append to {}: {}",
+                path.display(), e);
+        } else if is_new {
+            eprintln!(
+                "proptest: Saving this and future failures in {}",
+                path.display());
+        }
+    }
+}
+
 fn panic_guard<V, F>(case: &V, test: &F) -> TestCaseResult
 where
     F: Fn(&V) -> TestCaseResult
 {
     match panic::catch_unwind(AssertUnwindSafe(|| test(&case))) {
         Ok(r) => r,
-        Err(what) => fail_case(
+        Err(what) => Err(TestCaseError::fail(
             what.downcast::<&'static str>().map(|s| reject(*s))
                 .or_else(|what| what.downcast::<String>().map(|b| reject(*b)))
                 .or_else(|what| what.downcast::<Box<str>>().map(|b| reject(*b)))
-                .unwrap_or_else(|_| reject("<unknown panic value>"))),
+                .unwrap_or_else(|_| reject("<unknown panic value>")))),
     }
 }
 
@@ -329,21 +584,26 @@ impl TestRunner {
             flat_map_regens: Arc::new(AtomicUsize::new(0)),
             local_reject_detail: BTreeMap::new(),
             global_reject_detail: BTreeMap::new(),
+            source_file: None,
         }
     }
 
     /// Create a fresh `TestRunner` with the same config and global counters as
-    /// this one, but with local state reset and an independent `Rng`.
-    pub(crate) fn partial_clone(&self) -> Self {
+    /// this one, but with local state reset and an independent `Rng` (but
+    /// deterministic).
+    pub(crate) fn partial_clone(&mut self) -> Self {
+        let rng = self.new_rng();
+
         TestRunner {
             config: self.config.clone(),
             successes: 0,
             local_rejects: 0,
             global_rejects: 0,
-            rng: rand::weak_rng(),
+            rng: rng,
             flat_map_regens: Arc::clone(&self.flat_map_regens),
             local_reject_detail: BTreeMap::new(),
             global_reject_detail: BTreeMap::new(),
+            source_file: self.source_file.clone(),
         }
     }
 
@@ -352,9 +612,97 @@ impl TestRunner {
         &mut self.rng
     }
 
+    fn new_rng_seed(&mut self) -> [u32;4] {
+        let mut seed = <[u32;4] as Rand>::rand(&mut self.rng);
+        // Directly using XorShiftRng::from_seed() at this point would result
+        // in self.rng and the returned value being exactly the same. Perturb
+        // the seed with some arbitrary values to prevent this.
+        for word in &mut seed {
+            *word ^= 0xdeadbeef;
+        }
+        seed
+    }
+
+    /// Create a new, independent but deterministic RNG from the RNG in this
+    /// runner.
+    pub fn new_rng(&mut self) -> XorShiftRng {
+        XorShiftRng::from_seed(self.new_rng_seed())
+    }
+
     /// Returns the configuration of this runner.
     pub fn config(&self) -> &Config {
         &self.config
+    }
+
+    /// Set the source file to use for resolving the location of the persisted
+    /// failing cases file.
+    ///
+    /// The source location can only be used if it is absolute. If `source` is
+    /// not an absolute path, an attempt will be made to determine the absolute
+    /// path based on the current working directory and its parents. If no
+    /// absolute path can be determined, a warning will be printed and proptest
+    /// will continue as if this function had never been called.
+    ///
+    /// See [`FailurePersistence`](enum.FailurePersistence.html) for details on
+    /// how this value is used once it is made absolute.
+    ///
+    /// This is normally called automatically by the `proptest!` macro, which
+    /// passes `file!()`.
+    pub fn set_source_file(&mut self, source: &'static Path) {
+        self.set_source_file_with_cwd(env::current_dir, source)
+    }
+
+    pub(crate) fn set_source_file_with_cwd<F>(
+        &mut self, getcwd: F,
+        source: &'static Path)
+    where F : FnOnce () -> io::Result<PathBuf> {
+        self.source_file = if source.is_absolute() {
+            // On Unix, `file!()` is absolute. In these cases, we can use
+            // that path directly.
+            Some(Cow::Borrowed(source))
+        } else {
+            // On Windows, `file!()` is relative to the crate root, but the
+            // test is not generally run with the crate root as the working
+            // directory, so the path is not directly usable. However, the
+            // working directory is almost always a subdirectory of the crate
+            // root, so pop directories off until pushing the source onto the
+            // directory results in a path that refers to an existing file.
+            // Once we find such a path, we can use that.
+            //
+            // If we can't figure out an absolute path, print a warning and act
+            // as if no source had been given.
+            match getcwd() {
+                Ok(mut cwd) => {
+                    loop {
+                        let joined = cwd.join(source);
+                        if joined.is_file() {
+                            break Some(Cow::Owned(joined));
+                        }
+
+                        if !cwd.pop() {
+                            eprintln!(
+                                "proptest: Failed to find absolute path of \
+                                 source file '{:?}'. Ensure the test is \
+                                 being run from somewhere within the crate \
+                                 directory hierarchy.", source);
+                            break None;
+                        }
+                    }
+                },
+
+                Err(e) => {
+                    eprintln!("proptest: Failed to determine current \
+                               directory, so the relative source path \
+                               '{:?}' cannot be resolved: {}",
+                              source, e);
+                    None
+                }
+            }
+        }
+    }
+
+    pub(crate) fn source_file(&self) -> Option<&Path> {
+        self.source_file.as_ref().map(|cow| &**cow)
     }
 
     /// Run test cases against `f`, choosing inputs via `strategy`.
@@ -363,22 +711,54 @@ impl TestRunner {
     /// report that. If invoking `f` panics, the panic is turned into a
     /// `TestCaseError::Fail`.
     ///
+    /// If failure persistence is enabled, all persisted failing cases are
+    /// tested first. If a later non-persisted case fails, its seed is
+    /// persisted before returning failure.
+    ///
     /// Returns success or failure indicating why the test as a whole failed.
     pub fn run<S : Strategy,
                F : Fn (&ValueFor<S>) -> TestCaseResult>
         (&mut self, strategy: &S, test: F)
          -> Result<(), TestError<ValueFor<S>>>
     {
+        let persist_path = self.config.failure_persistence.resolve(
+            self.source_file());
+
+        let old_rng = self.rng.clone();
+        for persisted_seed in load_persisted_failures(persist_path.as_ref())
+        {
+            self.rng = XorShiftRng::from_seed(persisted_seed);
+            self.gen_and_run_case(strategy, &test)?;
+        }
+        self.rng = old_rng;
+
         while self.successes < self.config.cases {
-            let case = match strategy.new_value(self) {
-                Ok(v) => v,
-                Err(msg) => return Err(TestError::Abort(msg)),
-            };
-            if self.run_one(case, &test)? {
-                self.successes += 1;
+            // Generate a new seed and make an RNG from that so that we know
+            // what seed to persist if this case fails.
+            let seed = self.new_rng_seed();
+            self.rng = XorShiftRng::from_seed(seed);
+            let result = self.gen_and_run_case(strategy, &test);
+            if let Err(TestError::Fail(_, ref value)) = result {
+                save_persisted_failure(persist_path.as_ref(), seed, value);
             }
+
+            let _ = result?;
         }
 
+        Ok(())
+    }
+
+    fn gen_and_run_case<S : Strategy, F : Fn (&ValueFor<S>) -> TestCaseResult>
+        (&mut self, strategy: &S, f: &F)
+        -> Result<(), TestError<ValueFor<S>>>
+    {
+        let case = match strategy.new_value(self) {
+            Ok(v) => v,
+            Err(msg) => return Err(TestError::Abort(msg)),
+        };
+        if self.run_one(case, f)? {
+            self.successes += 1;
+        }
         Ok(())
     }
 
@@ -484,8 +864,10 @@ impl TestRunner {
 #[cfg(test)]
 mod test {
     use std::cell::Cell;
+    use std::fs;
 
     use super::*;
+    use strategy::Strategy;
 
     #[test]
     fn gives_up_after_too_many_rejections() {
@@ -494,7 +876,7 @@ mod test {
         let runs = Cell::new(0);
         let result = runner.run(&(0u32..), |_| {
             runs.set(runs.get() + 1);
-            reject_case("reject")
+            Err(TestCaseError::reject("reject"))
         });
         match result {
             Err(TestError::Abort(_)) => (),
@@ -512,11 +894,14 @@ mod test {
 
     #[test]
     fn test_fail_via_result() {
-        let mut runner = TestRunner::default();
+        let mut runner = TestRunner::new(Config {
+            failure_persistence: FailurePersistence::Off,
+            .. Config::default()
+        });
         let result = runner.run(&(0u32..10u32), |&v| if v < 5 {
             Ok(())
         } else {
-            fail_case("not less than 5")
+            Err(TestCaseError::fail("not less than 5"))
         });
 
         assert_eq!(Err(TestError::Fail("not less than 5".into(), 5)), result);
@@ -524,11 +909,193 @@ mod test {
 
     #[test]
     fn test_fail_via_panic() {
-        let mut runner = TestRunner::default();
+        let mut runner = TestRunner::new(Config {
+            failure_persistence: FailurePersistence::Off,
+            .. Config::default()
+        });
         let result = runner.run(&(0u32..10u32), |&v| {
             assert!(v < 5, "not less than 5");
             Ok(())
         });
         assert_eq!(Err(TestError::Fail("not less than 5".into(), 5)), result);
+    }
+
+    struct TestPaths {
+        crate_root: &'static Path,
+        src_file: PathBuf,
+        subdir_file: PathBuf,
+        misplaced_file: PathBuf,
+        test_runner_relative: PathBuf,
+    }
+
+    lazy_static! {
+        static ref TEST_PATHS: TestPaths = {
+            let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+            let lib_root = crate_root.join("src");
+            let src_subdir = lib_root.join("strategy");
+            let src_file = lib_root.join("foo.rs");
+            let subdir_file = src_subdir.join("foo.rs");
+            let misplaced_file = crate_root.join("foo.rs");
+            let test_runner_relative = ["src", "test_runner.rs"]
+                .iter().collect();
+            TestPaths {
+                crate_root,
+                src_file, subdir_file, misplaced_file,
+                test_runner_relative,
+            }
+        };
+    }
+
+    #[test]
+    fn persistence_file_location_resolved_correctly() {
+        // If off, there is never a file
+        assert_eq!(None, FailurePersistence::Off.resolve(None));
+        assert_eq!(None, FailurePersistence::Off.resolve(
+            Some(&TEST_PATHS.subdir_file)));
+
+        // For direct, we don't care about the source file, and instead always
+        // use whatever is in the config.
+        assert_eq!(Some(Path::new("bar.txt").to_owned()),
+                   FailurePersistence::Direct("bar.txt").resolve(None));
+        assert_eq!(Some(Path::new("bar.txt").to_owned()),
+                   FailurePersistence::Direct("bar.txt").resolve(
+                       Some(&TEST_PATHS.subdir_file)));
+
+        // For WithSource, only the extension changes, but we get nothing if no
+        // source file was configured.
+        // Accounting for the way absolute paths work on Windows would be more
+        // complex, so for now don't test that case.
+        #[cfg(unix)]
+        fn absolute_path_case() {
+            assert_eq!(Some(Path::new("/foo/bar.ext").to_owned()),
+                       FailurePersistence::WithSource("ext").resolve(
+                           Some(Path::new("/foo/bar.rs"))));
+        }
+        #[cfg(not(unix))]
+        fn absolute_path_case() { }
+        absolute_path_case();
+        assert_eq!(None,
+                   FailurePersistence::WithSource("ext").resolve(None));
+
+        // For SourceParallel, we make a sibling directory tree and change the
+        // extensions to .txt ...
+        assert_eq!(Some(TEST_PATHS.crate_root.join("sib").join("foo.txt")),
+                   FailurePersistence::SourceParallel("sib").resolve(
+                       Some(&TEST_PATHS.src_file)));
+        assert_eq!(Some(TEST_PATHS.crate_root.join("sib")
+                        .join("strategy").join("foo.txt")),
+                   FailurePersistence::SourceParallel("sib").resolve(
+                       Some(&TEST_PATHS.subdir_file)));
+        // ... but if we can't find lib.rs / main.rs, give up and set the
+        // extension instead ...
+        assert_eq!(Some(TEST_PATHS.crate_root.join("foo.sib")),
+                   FailurePersistence::SourceParallel("sib").resolve(
+                       Some(&TEST_PATHS.misplaced_file)));
+        // ... and if no source is configured, we do nothing
+        assert_eq!(None,
+                   FailurePersistence::SourceParallel("ext").resolve(None));
+    }
+
+    #[derive(Clone, Copy, PartialEq)]
+    struct PoorlyBehavedDebug(i32);
+    impl fmt::Debug for PoorlyBehavedDebug {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "\r\n{:?}\r\n", self.0)
+        }
+    }
+
+    #[test]
+    fn failing_cases_persisted_and_reloaded() {
+        const FILE: &'static str = "persistence-test.txt";
+        let _ = fs::remove_file(FILE);
+
+        let max = 10_000_000i32;
+        let input = (0i32..max).prop_map(PoorlyBehavedDebug);
+        let config = Config {
+            failure_persistence: FailurePersistence::Direct(FILE),
+            .. Config::default()
+        };
+
+        // First test with cases that fail above half max, and then below half
+        // max, to ensure we can correctly parse both lines of the persistence
+        // file.
+        let first_sub_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 < max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::fail("too big"))
+                }
+            }).err().expect("didn't fail?")
+        };
+        let first_super_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 >= max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::fail("too small"))
+                }
+            }).err().expect("didn't fail?")
+        };
+        let second_sub_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 < max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::fail("too big"))
+                }
+            }).err().expect("didn't fail?")
+        };
+        let second_super_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 >= max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::fail("too small"))
+                }
+            }).err().expect("didn't fail?")
+        };
+
+        assert_eq!(first_sub_failure, second_sub_failure);
+        assert_eq!(first_super_failure, second_super_failure);
+    }
+
+    #[test]
+    fn relative_source_files_absolutified() {
+        let expected = [
+            env!("CARGO_MANIFEST_DIR"),
+            "src",
+            "test_runner.rs",
+        ].iter().collect::<PathBuf>();
+
+        let mut runner = TestRunner::default();
+        // Running from crate root
+        runner.set_source_file_with_cwd(
+            || Ok(Path::new(env!("CARGO_MANIFEST_DIR")).to_owned()),
+            &TEST_PATHS.test_runner_relative);
+        assert_eq!(&*expected, runner.source_file().unwrap());
+
+        // Running from test subdirectory
+        runner.set_source_file_with_cwd(
+            || Ok(Path::new(env!("CARGO_MANIFEST_DIR"))
+                  .join("target")),
+            &TEST_PATHS.test_runner_relative);
+        assert_eq!(&*expected, runner.source_file().unwrap());
+    }
+
+    #[test]
+    fn new_rng_makes_separate_rng() {
+        let mut runner = TestRunner::default();
+        let mut rng2 = runner.new_rng();
+        let rng1 = runner.rng();
+
+        let from_1 = <[u32;4] as Rand>::rand(rng1);
+        let from_2 = <[u32;4] as Rand>::rand(&mut rng2);
+
+        assert_ne!(from_1, from_2);
     }
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -522,7 +522,7 @@ mod test {
             Err(fail_case("not less than 5"))
         });
 
-        assert_eq!(Err(fail_case("not less than 5", 5)), result);
+        assert_eq!(Err(TestError::Fail("not less than 5".into(), 5)), result);
     }
 
     #[test]
@@ -532,6 +532,6 @@ mod test {
             assert!(v < 5, "not less than 5");
             Ok(())
         });
-        assert_eq!(Err(fail_case("not less than 5", 5)), result);
+        assert_eq!(Err(TestError::Fail("not less than 5".into(), 5)), result);
     }
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -296,7 +296,7 @@ impl fmt::Display for TestRunner {
     }
 }
 
-/// Equivalent to: `TestRunner::new(Config::default())`.
+/// Equivalent to: `TestRunner::default()`.
 impl Default for TestRunner {
     fn default() -> Self {
         Self::new(Config::default())

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -211,7 +211,7 @@ impl fmt::Display for TestCaseError {
 
 impl<E : ::std::error::Error> From<E> for TestCaseError {
     fn from(cause: E) -> Self {
-        TestCaseError::Fail(cause.to_string().into())
+        fail_case(cause.to_string())
     }
 }
 
@@ -389,7 +389,7 @@ impl TestRunner {
                             .or_else(|what|
                                 what.downcast::<Box<str>>().map(|b| reject(*b)))
                             .unwrap_or_else(|_| reject("<unknown panic value>"));
-                        Err(TestCaseError::Fail(msg))
+                        Err(fail_case(msg))
                     },
                 }
             } }
@@ -426,7 +426,6 @@ impl TestRunner {
                 Err(TestError::Fail(last_failure.0, last_failure.1))
             },
             Err(TestCaseError::Reject(whence)) => {
-                let whence = reject(whence); // FIXME.
                 self.reject_global(whence)?;
                 Ok(false)
             },

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -111,6 +111,7 @@ pub struct Config {
     #[doc(hidden)]
     pub _non_exhaustive: (),
 }
+
 impl Config {
     /// Constructs a `Config` only differing from the `default()` in the
     /// number of test cases required to pass the test successfully.
@@ -132,7 +133,6 @@ impl Config {
         }
     }
 }
-
 
 impl Default for Config {
     fn default() -> Self {
@@ -157,12 +157,12 @@ pub enum TestCaseError {
     ///
     /// The string gives the location and context of the rejection, and
     /// should be suitable for formatting like `Foo did X at {whence}`.
-    Reject(String),
+    Reject(Rejection),
     /// The code under test failed the test.
     ///
     /// The string should indicate the location of the failure, but may
     /// generally be any string.
-    Fail(String),
+    Fail(Rejection),
 }
 
 /// Convenience for the type returned by test cases.
@@ -181,7 +181,7 @@ impl fmt::Display for TestCaseError {
 
 impl<E : ::std::error::Error> From<E> for TestCaseError {
     fn from(cause: E) -> Self {
-        TestCaseError::Fail(cause.to_string())
+        TestCaseError::Fail(cause.to_string().into())
     }
 }
 
@@ -190,11 +190,11 @@ impl<E : ::std::error::Error> From<E> for TestCaseError {
 pub enum TestError<T> {
     /// The test was aborted for the given reason, for example, due to too many
     /// inputs having been rejected.
-    Abort(String),
+    Abort(Rejection),
     /// A failing test case was found. The string indicates where and/or why
     /// the test failed. The `T` is the minimal input found to reproduce the
     /// failure.
-    Fail(String, T),
+    Fail(Rejection, T),
 }
 
 impl<T : fmt::Debug> fmt::Display for TestError<T> {
@@ -218,6 +218,8 @@ impl<T : fmt::Debug> ::std::error::Error for TestError<T> {
     }
 }
 
+type RejectionDetail = BTreeMap<Rejection, u32>;
+
 /// State used when running a proptest test.
 #[derive(Clone)]
 pub struct TestRunner {
@@ -228,8 +230,8 @@ pub struct TestRunner {
     rng: XorShiftRng,
     flat_map_regens: Arc<AtomicUsize>,
 
-    local_reject_detail: BTreeMap<String, u32>,
-    global_reject_detail: BTreeMap<String, u32>,
+    local_reject_detail: RejectionDetail,
+    global_reject_detail: RejectionDetail,
 }
 
 impl fmt::Debug for TestRunner {
@@ -351,10 +353,12 @@ impl TestRunner {
                     Ok(r) => r,
                     Err(what) => {
                         let msg = what.downcast::<&'static str>()
-                            .map(|s| (*s).to_owned())
-                            .or_else(|what| what.downcast::<String>().map(|b| *b))
-                            .unwrap_or_else(
-                                |_| "<unknown panic value>".to_owned());
+                            .map(|s| reject(*s))
+                            .or_else(|what|
+                                what.downcast::<String>().map(|b| reject(*b)))
+                            .or_else(|what|
+                                what.downcast::<Box<str>>().map(|b| reject(*b)))
+                            .unwrap_or_else(|_| reject("<unknown panic value>"));
                         Err(TestCaseError::Fail(msg))
                     },
                 }
@@ -392,7 +396,8 @@ impl TestRunner {
                 Err(TestError::Fail(last_failure.0, last_failure.1))
             },
             Err(TestCaseError::Reject(whence)) => {
-                self.reject_global(&whence)?;
+                let whence = reject(whence); // FIXME.
+                self.reject_global(whence)?;
                 Ok(false)
             },
         }
@@ -400,48 +405,45 @@ impl TestRunner {
 
     /// Update the state to account for a local rejection from `whence`, and
     /// return `Ok` if the caller should keep going or `Err` to abort.
-    pub fn reject_local(&mut self, whence: String) -> Result<(),String> {
+    pub fn reject_local<R>(&mut self, whence: R) -> Result<(), Rejection>
+    where
+        R: Into<Rejection>
+    {
         if self.local_rejects >= self.config.max_local_rejects {
-            Err("Too many local rejects".to_owned())
+            Err(reject("Too many local rejects"))
         } else {
             self.local_rejects += 1;
-            let need_insert = if let Some(count) =
-                self.local_reject_detail.get_mut(&whence)
-            {
-                *count += 1;
-                false
-            } else {
-                true
-            };
-            if need_insert {
-                self.local_reject_detail.insert(whence, 1);
-            }
-
+            Self::insert_or_increment(&mut self.local_reject_detail,
+                whence.into());
             Ok(())
         }
     }
 
     /// Update the state to account for a global rejection from `whence`, and
     /// return `Ok` if the caller should keep going or `Err` to abort.
-    fn reject_global<T>(&mut self, whence: &str) -> Result<(),TestError<T>> {
+    fn reject_global<T>(&mut self, whence: Rejection) -> Result<(),TestError<T>> {
         if self.global_rejects >= self.config.max_global_rejects {
-            Err(TestError::Abort("Too many global rejects".to_owned()))
+            Err(TestError::Abort(reject("Too many global rejects")))
         } else {
             self.global_rejects += 1;
-            let need_insert = if let Some(count) =
-                self.global_reject_detail.get_mut(whence)
-            {
-                *count += 1;
-                false
-            } else {
-                true
-            };
-            if need_insert {
-                self.global_reject_detail.insert(whence.to_owned(), 1);
-            }
-
+            Self::insert_or_increment(&mut self.global_reject_detail, whence);
             Ok(())
         }
+    }
+
+    /// Insert 1 or increment the rejection detail at key for whence.
+    fn insert_or_increment(into: &mut RejectionDetail, whence: Rejection) {
+        use std::collections::btree_map::Entry::*;
+        match into.entry(whence) {
+            Occupied(oe) => { *oe.into_mut() += 1; },
+            Vacant(ve)   => { ve.insert(1); },
+        }
+        /*
+        // TODO: Replace with once and_modify is stable:
+        into.entry(whence)
+            .and_modify(|count| { *count += 1 })
+            .or_insert(1);
+        */
     }
 
     /// Increment the counter of flat map regenerations and return whether it
@@ -465,7 +467,7 @@ mod test {
         let runs = Cell::new(0);
         let result = runner.run(&(0u32..), |_| {
             runs.set(runs.get() + 1);
-            Err(TestCaseError::Reject("reject".to_owned()))
+            Err(TestCaseError::Reject("reject".into()))
         });
         match result {
             Err(TestError::Abort(_)) => (),
@@ -487,11 +489,10 @@ mod test {
         let result = runner.run(&(0u32..10u32), |&v| if v < 5 {
             Ok(())
         } else {
-            Err(TestCaseError::Fail("not less than 5".to_owned()))
+            Err(TestCaseError::Fail("not less than 5".into()))
         });
 
-        assert_eq!(Err(TestError::Fail("not less than 5".to_owned(), 5)),
-                   result);
+        assert_eq!(Err(TestError::Fail("not less than 5".into(), 5)), result);
     }
 
     #[test]
@@ -501,7 +502,6 @@ mod test {
             assert!(v < 5, "not less than 5");
             Ok(())
         });
-        assert_eq!(Err(TestError::Fail("not less than 5".to_owned(), 5)),
-                   result);
+        assert_eq!(Err(TestError::Fail("not less than 5".into(), 5)), result);
     }
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -296,7 +296,7 @@ impl fmt::Display for TestRunner {
     }
 }
 
-/// Equivalent to: `TestRunner::default()`.
+/// Equivalent to: `TestRunner::default(Config::default())`.
 impl Default for TestRunner {
     fn default() -> Self {
         Self::new(Config::default())

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -42,10 +42,7 @@ macro_rules! tuple {
         impl<$($typ : Strategy),*> Strategy for ($($typ,)*) {
             type Value = TupleValueTree<($($typ::Value,)*)>;
 
-            fn new_value
-                (&self, runner: &mut TestRunner)
-                -> Result<Self::Value, String>
-            {
+            fn new_value(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 let values = ($(self.$fld.new_value(runner)?,)*);
                 Ok(TupleValueTree::new(values))
             }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -112,7 +112,7 @@ mod test {
         }
 
         let input = (0..32, 0..32);
-        let mut runner = TestRunner::new(Config::default());
+        let mut runner = TestRunner::default();
 
         let mut cases_tested = 0;
         for _ in 0..256 {


### PR DESCRIPTION
## Release strategy

- Since this bumps to 0.4.0 it might be prudent to add in more breaking changes while we're at it.

## What's included

- Some cleanup
- Some semantic compression
- Possible speedups by avoiding calling `case.current()` a bit
- More below..

### Potential Breaking Changes

- Instead of returning `-> Result<Self::Value, String>`, strategies are expected
  to return `-> Result<Self::Value, Rejection>` instead. `Rejection` reduces
  the amount of heap allocations, especially for `.prop_filter(..)` where
  you may now also pass in `&'static str` as well as `Rc<str>`.
  You will only experience breaks if you've written your own strategy types
  or if you've used `TestCaseError::Reject` or `TestCaseError::Fail` expliclty.

### New Additions

- Added `proptest::strategy::Rejection` which allows you to avoid heap allocation
  in some places or share allocation with string-interning.

- Added a type alias `proptest::strategy::NewTree<S>` where `S: Strategy`
  defined as: `type NewTree<S> = Result<<S as Strategy>::Value, Rejection>`.

- Added `TestCaseError::reject` and `reject_case` (short-hand).

- Added `TestCaseError::fail` and `fail_case` (short-hand).