### PR TITLE
Add failing case persistence.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 
 # VSCode:
 .vscode/
+persistence-test.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   Rust, this is hidden behind the feature `unstable` which you have to
   explicitly opt into in your `Cargo.toml` file.
 
+- Failing case persistence. By default, when a test fails, Proptest will now
+  save the seed for the failing test to a file, and later runs will test the
+  persisted failing cases before generating new ones.
+
 ## 0.3.2
 
 ### New Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   save the seed for the failing test to a file, and later runs will test the
   persisted failing cases before generating new ones.
 
+### Bug Fixes
+
+- Fix a case where certain combinations of strategies, like two
+  `prop_shuffle()`s in close proximity, could result in low-quality randomness.
+
 ## 0.3.2
 
 ### New Additions

--- a/README.md
+++ b/README.md
@@ -120,8 +120,17 @@ thread 'main' panicked at 'Test failed: byte index 4 is not a char boundary; it 
 '
 ```
 
-The first thing we should do is copy the failing case to a traditional unit
-test since it has exposed a bug.
+The first thing we should do is add the new [failure
+persistence](#failure-persistence) file to our source control, for example
+with git:
+
+```text
+$ git add src/proptest-failures.txt
+```
+
+The next thing we should do is copy the failing case to a traditional unit
+test since it has exposed a bug not similar to what we've tested in the
+past.
 
 ```rust
 #[test]
@@ -270,7 +279,12 @@ Between those two, though, we see something different: it tried to shrink
 the `0000-06-20` and `0000-09-20` test cases _passed_.
 
 In the end, we get the date `0000-10-01`, which apparently gets parsed as
-`0000-00-01`. Again, let's add this as its own unit test:
+`0000-00-01`. Again, this failing case was added to the failure persistence
+file, and we should add this as its own unit test:
+
+```text
+$ git add src/proptest-failures.txt
+```
 
 ```rust
 #[test]
@@ -379,6 +393,43 @@ Similarly, in some cases it can be hard or impossible to define a strategy
 which actually produces useful inputs. A strategy of `.{1,4096}` may be
 great to fuzz a C parser, but is highly unlikely to produce anything that
 makes it to a code generator.
+
+## Failure Persistence
+
+By default, when Proptest finds a failing test case, it _persists_ that
+failing case in a file named `proptest-failures.txt` at the root of your
+source tree. Later runs of tests will replay those test cases before
+generating novel cases. This ensures that the test will not fail on one run
+and then spuriously pass on the next, and also exposes similar tests to the
+same known-problematic input.
+
+It is recommended to check this file in to your source control so that
+other test runners (e.g., collaborators or a CI system) also replay these
+cases.
+
+Note that, by default, all tests in the same crate will share that one
+persistence file. If you have a very large number of tests, it may be
+desirable to separate them into smaller groups so the number of extra test
+cases that get run is reduced. This can be done by adjusting the
+`failure_persistence` flag on `Config`.
+
+There are two ways this persistence could theoretically be done.
+
+The immediately obvious option is to persist a representation of the value
+itself, for example by using Serde. While this has some advantages,
+particularly being resistant to changes like tweaking the input strategy,
+it also has a lot of problems. Most importantly, there is no way to
+determine whether any given value is actually within the domain of the
+strategy that produces it. Thus, some (likely extremely fragile) mechanism
+to ensure that the strategy that produced the value exactly matches the one
+in use in a test case would be required.
+
+The other option is to store the _seed_ that was used to produce the
+failing test case. This approach requires no support from the strategy or
+the produced value. If the strategy in use differs from the one used to
+produce failing case that was persisted, the seed may or may not produce
+the problematic value, but nonetheless produces a valid value. Due to these
+advantages, this is the approach Proptest uses.
 
 
 # Acknowledgements

--- a/README.md
+++ b/README.md
@@ -120,12 +120,14 @@ thread 'main' panicked at 'Test failed: byte index 4 is not a char boundary; it 
 '
 ```
 
-The first thing we should do is add the new [failure
-persistence](#failure-persistence) file to our source control, for example
-with git:
+If we look at the top directory after the test fails, we'll see a new
+`proptest-regressions` directory, which contains some files corresponding
+to source files containing failing test cases. These are [_failure
+persistence_](#failure-persistence) files. The first thing we should do is
+add these to source control.
 
 ```text
-$ git add src/proptest-failures.txt
+$ git add proptest-regressions
 ```
 
 The next thing we should do is copy the failing case to a traditional unit
@@ -283,7 +285,7 @@ In the end, we get the date `0000-10-01`, which apparently gets parsed as
 file, and we should add this as its own unit test:
 
 ```text
-$ git add src/proptest-failures.txt
+$ git add proptest-regressions
 ```
 
 ```rust
@@ -397,13 +399,17 @@ makes it to a code generator.
 ## Failure Persistence
 
 By default, when Proptest finds a failing test case, it _persists_ that
-failing case in a file named `proptest-failures.txt` at the root of your
-source tree. Later runs of tests will replay those test cases before
-generating novel cases. This ensures that the test will not fail on one run
-and then spuriously pass on the next, and also exposes similar tests to the
-same known-problematic input.
+failing case in a file named after the source containing the failing test,
+but in a separate directory tree rooted at `proptest-regressions`† . Later
+runs of tests will replay those test cases before generating novel cases.
+This ensures that the test will not fail on one run and then spuriously
+pass on the next, and also exposes similar tests to the same
+known-problematic input.
 
-It is recommended to check this file in to your source control so that
+(†  If you do not have an obvious source directory, you may instead find
+files next to the source files, with a different extension.)
+
+It is recommended to check these files in to your source control so that
 other test runners (e.g., collaborators or a CI system) also replay these
 cases.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,12 +128,14 @@
 //! '
 //! ```
 //!
-//! The first thing we should do is add the new [failure
-//! persistence](#failure-persistence) file to our source control, for example
-//! with git:
+//! If we look at the top directory after the test fails, we'll see a new
+//! `proptest-regressions` directory, which contains some files corresponding
+//! to source files containing failing test cases. These are [_failure
+//! persistence_](#failure-persistence) files. The first thing we should do is
+//! add these to source control.
 //!
 //! ```text
-//! $ git add src/proptest-failures.txt
+//! $ git add proptest-regressions
 //! ```
 //!
 //! The next thing we should do is copy the failing case to a traditional unit
@@ -291,7 +293,7 @@
 //! file, and we should add this as its own unit test:
 //!
 //! ```text
-//! $ git add src/proptest-failures.txt
+//! $ git add proptest-regressions
 //! ```
 //!
 //! ```rust,ignore
@@ -413,13 +415,17 @@
 //! ## Failure Persistence
 //!
 //! By default, when Proptest finds a failing test case, it _persists_ that
-//! failing case in a file named `proptest-failures.txt` at the root of your
-//! source tree. Later runs of tests will replay those test cases before
-//! generating novel cases. This ensures that the test will not fail on one run
-//! and then spuriously pass on the next, and also exposes similar tests to the
-//! same known-problematic input.
+//! failing case in a file named after the source containing the failing test,
+//! but in a separate directory tree rooted at `proptest-regressions`† . Later
+//! runs of tests will replay those test cases before generating novel cases.
+//! This ensures that the test will not fail on one run and then spuriously
+//! pass on the next, and also exposes similar tests to the same
+//! known-problematic input.
 //!
-//! It is recommended to check this file in to your source control so that
+//! (†  If you do not have an obvious source directory, you may instead find
+//! files next to the source files, with a different extension.)
+//!
+//! It is recommended to check these files in to your source control so that
 //! other test runners (e.g., collaborators or a CI system) also replay these
 //! cases.
 //!

--- a/src/strategy/map.rs
+++ b/src/strategy/map.rs
@@ -10,7 +10,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use rand::{Rng, SeedableRng, XorShiftRng};
+use rand::XorShiftRng;
 
 use strategy::traits::*;
 use test_runner::*;
@@ -103,7 +103,7 @@ Strategy for Perturb<S, F> {
 
     fn new_value(&self, runner: &mut TestRunner)
                  -> Result<Self::Value, String> {
-        let rng = XorShiftRng::from_seed(runner.rng().gen());
+        let rng = runner.new_rng();
 
         self.source.new_value(runner).map(
             |v| PerturbValueTree {
@@ -163,6 +163,8 @@ ValueTree for PerturbValueTree<S, F> {
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;
+
+    use rand::Rng;
 
     use super::*;
 

--- a/src/strategy/shuffle.rs
+++ b/src/strategy/shuffle.rs
@@ -10,7 +10,7 @@
 use std::cell::Cell;
 use std::collections::VecDeque;
 
-use rand::{Rng, SeedableRng, XorShiftRng};
+use rand::{Rng, XorShiftRng};
 
 use num;
 use strategy::traits::*;
@@ -93,7 +93,7 @@ where ValueFor<S> : Shuffleable {
 
     fn new_value(&self, runner: &mut TestRunner)
                  -> Result<Self::Value, String> {
-        let rng = XorShiftRng::from_seed(runner.rng().gen());
+        let rng = runner.new_rng();
 
         self.0.new_value(runner).map(|inner| ShuffleValueTree {
             inner, rng,

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -36,6 +36,13 @@ pub trait Strategy : fmt::Debug {
     /// This may fail if there are constraints on the generated value and the
     /// generator is unable to produce anything that satisfies them. Any
     /// failure is wrapped in `TestError::Abort`.
+    ///
+    /// This method is generally expected to be deterministic. That is, given a
+    /// `TestRunner` with its RNG in a particular state, this should produce an
+    /// identical `ValueTree` every time. Non-deterministic strategies do not
+    /// cause problems during normal operation, but they do break failure
+    /// persistence since it is implemented by simply saving the seed used to
+    /// generate the test case.
     fn new_value
         (&self, runner: &mut TestRunner)
          -> Result<Self::Value, String>;

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -82,6 +82,7 @@ macro_rules! proptest {
             fn $test_name() {
                 let mut runner = $crate::test_runner::TestRunner::new(
                     $config.clone());
+                runner.set_source_file(::std::path::Path::new(file!()));
                 let names = proptest_helper!(@_WRAPSTR ($($parm),*));
                 match runner.run(
                     &$crate::strategy::Strategy::prop_map(

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -16,12 +16,15 @@ use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
+use std::fs;
+use std::io::{self, BufRead, Write};
 use std::panic::{self, AssertUnwindSafe};
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 
-use rand::{self, XorShiftRng};
+use rand::{self, Rand, SeedableRng, XorShiftRng};
 
 use strategy::*;
 
@@ -34,6 +37,7 @@ lazy_static! {
             max_local_rejects: 65536,
             max_global_rejects: 1024,
             max_flat_map_regens: 1_000_000,
+            failure_persistence: FailurePersistence::default(),
             _non_exhaustive: (),
         };
 
@@ -85,6 +89,8 @@ pub struct Config {
     /// The number of successful test cases that must execute for the test as a
     /// whole to pass.
     ///
+    /// This does not include implicitly-replayed persisted failing cases.
+    ///
     /// The default is 256, which can be overridden by setting the
     /// `PROPTEST_CASES` environment variable.
     pub cases: u32,
@@ -107,10 +113,20 @@ pub struct Config {
     /// The default is 1_000_000, which can be overridden by setting the
     /// `PROPTEST_MAX_FLAT_MAP_REGENS` environment variable.
     pub max_flat_map_regens: u32,
+    /// Indicates how to determine the file to use for persisting failed test
+    /// results.
+    ///
+    /// See the docs of [`FailurePersistence`](enum.FailurePersistence.html)
+    /// for more information.
+    ///
+    /// The default is `FailurePersistence::WithMain("proptest-failures.txt")`.
+    /// The default cannot currently be overridden by an environment variable.
+    pub failure_persistence: FailurePersistence,
     // Needs to be public so FRU syntax can be used.
     #[doc(hidden)]
     pub _non_exhaustive: (),
 }
+
 impl Config {
     /// Constructs a `Config` only differing from the `default()` in the
     /// number of test cases required to pass the test successfully.
@@ -137,6 +153,107 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         DEFAULT_CONFIG.clone()
+    }
+}
+
+/// Describes how failing test cases are persisted.
+///
+/// Note that file names in this enum are `&str` rather than `&Path` since
+/// constant functions are not yet in Rust stable as of 2017-12-16.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FailurePersistence {
+    /// Completely disables persistence of failing test cases.
+    ///
+    /// This is semantically equivalent to `Direct("/dev/null")` on Unix and
+    /// `Direct("NUL")` on Windows (though it is internally handled by simply
+    /// not doing any I/O).
+    Off,
+    /// The path given to `TestRunner::set_source_file()` is parsed, and
+    /// proptest traverses the directory tree upwards. The string given in this
+    /// value is resolved against the first directory which contains `lib.rs`
+    /// or `main.rs`, as per
+    /// [`PathBuf::push`](https://doc.rust-lang.org/stable/std/path/struct.PathBuf.html#method.push).
+    ///
+    /// If no `lib.rs` or `main.rs` can be found, a warning is printed and this
+    /// option behaves like `WithSource`. If `TestRunner::set_source_file()`
+    /// has not been called, a warning is printed and this option behaves like
+    /// `Direct`.
+    WithMain(&'static str),
+    /// The path given to `TestRunner::set_source_file()` is parsed. The string
+    /// given in this value is resolved against the parent directory of the
+    /// source file, as per
+    /// [`PathBuf::push`](https://doc.rust-lang.org/stable/std/path/struct.PathBuf.html#method.push).
+    ///
+    /// If `TestRunner::set_source_ifle()` has not been called, a warning is
+    /// printed and this option behaves like `Direct`.
+    WithSource(&'static str),
+    /// The string given in this option is directly used as a file path without
+    /// any further processing.
+    Direct(&'static str),
+    #[doc(hidden)]
+    #[allow(missing_docs)]
+    _NonExhaustive,
+}
+
+impl Default for FailurePersistence {
+    fn default() -> Self {
+        FailurePersistence::WithMain("proptest-failures.txt")
+    }
+}
+
+impl FailurePersistence {
+    /// Given the nominal source path, determine the location of the failure
+    /// persistence file, if any.
+    fn resolve(&self, source: Option<&Path>) -> Option<PathBuf> {
+        match *self {
+            FailurePersistence::Off => None,
+
+            FailurePersistence::WithMain(path) => match source {
+                Some(source_path) => {
+                    let mut dir = source_path.to_owned();
+                    let mut found = false;
+                    while dir.pop() {
+                        if dir.join("lib.rs").is_file() ||
+                            dir.join("main.rs").is_file()
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if !found {
+                        eprintln!("proptest: FailurePersistence::WithMain set, \
+                                   but failed to find lib.rs or main.rs");
+                        FailurePersistence::WithSource(path).resolve(source)
+                    } else {
+                        Some(dir.join(path))
+                    }
+                },
+                None => {
+                    eprintln!("proptest: FailurePersistence::WithMain set, \
+                               but no source file known");
+                    Some(Path::new(path).to_owned())
+                },
+            },
+
+            FailurePersistence::WithSource(path) => match source {
+                Some(source_path) =>
+                    Some(source_path.parent().unwrap_or(source_path)
+                         .join(path)),
+
+                None => {
+                    eprintln!("proptest: FailurePersistence::WithSource set, \
+                               but no source file known");
+                    Some(Path::new(path).to_owned())
+                },
+            },
+
+            FailurePersistence::Direct(path) =>
+                Some(Path::new(path).to_owned()),
+
+            FailurePersistence::_NonExhaustive =>
+                panic!("FailurePersistence set to _NonExhaustive"),
+        }
     }
 }
 
@@ -230,6 +347,8 @@ pub struct TestRunner {
 
     local_reject_detail: BTreeMap<String, u32>,
     global_reject_detail: BTreeMap<String, u32>,
+
+    source_file: Option<&'static Path>,
 }
 
 impl fmt::Debug for TestRunner {
@@ -243,6 +362,7 @@ impl fmt::Debug for TestRunner {
             .field("flat_map_regens", &self.flat_map_regens)
             .field("local_reject_detail", &self.local_reject_detail)
             .field("global_reject_detail", &self.global_reject_detail)
+            .field("source_file", &self.source_file)
             .finish()
     }
 }
@@ -271,6 +391,119 @@ impl Default for TestRunner {
     }
 }
 
+lazy_static! {
+    /// Used to guard access to the persistence file(s) so that a single
+    /// process will not step on its own toes.
+    ///
+    /// We don't have much protecting us should two separate process try to
+    /// write to the same file at once (depending on how atomic append mode is
+    /// on the OS), but this should be extremely rare.
+    static ref PERSISTENCE_LOCK: RwLock<()> = RwLock::new(());
+}
+
+fn load_persisted_failures(path: Option<&PathBuf>) -> Vec<[u32;4]> {
+    let result: io::Result<Vec<[u32;4]>> =
+        path.map_or_else(|| Ok(vec![]), |path| {
+            // .ok() instead of .unwrap() so we don't propagate panics here
+            let _lock = PERSISTENCE_LOCK.read().ok();
+
+            let mut ret = Vec::new();
+
+            let input = io::BufReader::new(fs::File::open(path)?);
+            for (lineno, line) in input.lines().enumerate() {
+                let mut line = line?;
+                if let Some(comment_start) = line.find('#') {
+                    line.truncate(comment_start);
+                }
+
+                let parts = line.trim().split(' ').collect::<Vec<_>>();
+                if 5 == parts.len() && "xs" == parts[0] {
+                    let seed = parts[1].parse::<u32>().and_then(
+                        |a| parts[2].parse::<u32>().and_then(
+                            |b| parts[3].parse::<u32>().and_then(
+                                |c| parts[4].parse::<u32>().map(
+                                    |d| [a, b, c, d]))));
+                    if let Ok(seed) = seed {
+                        ret.push(seed);
+                    } else {
+                        eprintln!(
+                            "proptest: {}:{}: unparsable line, \
+                             ignoring", path.display(), lineno + 1);
+                    }
+                } else if parts.len() > 1 {
+                    eprintln!("proptest: {}:{}: unknown case type `{}` \
+                               (corrupt file or newer proptest version?)",
+                              path.display(), lineno + 1, parts[0]);
+                }
+            }
+
+            Ok(ret)
+        });
+
+    match result {
+        Ok(r) => r,
+        Err(err) => {
+            if io::ErrorKind::NotFound != err.kind() {
+                eprintln!(
+                    "proptest: failed to open {}: {}",
+                    path.map(|x| &**x).unwrap_or(Path::new("??")).display(),
+                    err);
+            }
+            vec![]
+        },
+    }
+}
+
+fn save_persisted_failure(path: Option<&PathBuf>,
+                          seed: [u32;4],
+                          value: &fmt::Debug) {
+    if let Some(path) = path {
+        // .ok() instead of .unwrap() so we don't propagate panics here
+        let _lock = PERSISTENCE_LOCK.write().ok();
+        let is_new = !path.is_file();
+
+        let mut to_write = Vec::<u8>::new();
+        if is_new {
+            writeln!(to_write, "\
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.")
+                    .expect("writeln! to vec failed");
+            }
+            let mut data_line = Vec::<u8>::new();
+            write!(data_line, "xs {} {} {} {} # shrinks to {:?}",
+                   seed[0], seed[1], seed[2], seed[3],
+                   value).expect("write! to vec failed");
+            // Ensure there are no newlines in the debug output
+            for byte in &mut data_line {
+                if b'\n' == *byte || b'\r' == *byte {
+                    *byte = b' ';
+                }
+            }
+
+            to_write.extend(data_line);
+            to_write.push(b'\n');
+
+            let mut options = fs::OpenOptions::new();
+            options.append(true).create(true);
+            let res = options.open(path).and_then(
+                |mut out| out.write_all(&to_write));
+
+            if let Err(e) = res {
+                eprintln!(
+                    "proptest: failed to append to {}: {}",
+                    path.display(), e);
+            } else if is_new {
+                eprintln!(
+                    "proptest: Saving this and future failures in {}",
+                    path.display());
+            }
+        }
+    }
+
 impl TestRunner {
     /// Create a fresh `TestRunner` with the given configuration.
     pub fn new(config: Config) -> Self {
@@ -283,6 +516,7 @@ impl TestRunner {
             flat_map_regens: Arc::new(AtomicUsize::new(0)),
             local_reject_detail: BTreeMap::new(),
             global_reject_detail: BTreeMap::new(),
+            source_file: None,
         }
     }
 
@@ -298,6 +532,7 @@ impl TestRunner {
             flat_map_regens: Arc::clone(&self.flat_map_regens),
             local_reject_detail: BTreeMap::new(),
             global_reject_detail: BTreeMap::new(),
+            source_file: self.source_file,
         }
     }
 
@@ -311,11 +546,27 @@ impl TestRunner {
         &self.config
     }
 
+    /// Set the source file to use for resolving the location of the persisted
+    /// failing cases file.
+    ///
+    /// See [`FailurePersistence`](enum.FailurePersistence.html) for details on
+    /// how this value is used.
+    ///
+    /// This is normally called automatically by the `proptest!` macro, which
+    /// passes `file!()`.
+    pub fn set_source_file(&mut self, source: &'static Path) {
+        self.source_file = Some(source);
+    }
+
     /// Run test cases against `f`, choosing inputs via `strategy`.
     ///
     /// If any failure cases occur, try to find a minimal failure case and
     /// report that. If invoking `f` panics, the panic is turned into a
     /// `TestCaseError::Fail`.
+    ///
+    /// If failure persistence is enabled, all persisted failing cases are
+    /// tested first. If a later non-persisted case fails, its seed is
+    /// persisted before returning failure.
     ///
     /// Returns success or failure indicating why the test as a whole failed.
     pub fn run<S : Strategy,
@@ -323,16 +574,44 @@ impl TestRunner {
         (&mut self, strategy: &S, f: F)
          -> Result<(), TestError<ValueFor<S>>>
     {
+        let persist_path =
+            self.config.failure_persistence.resolve(self.source_file);
+
+        let old_rng = self.rng.clone();
+        for persisted_seed in load_persisted_failures(persist_path.as_ref())
+        {
+            self.rng = XorShiftRng::from_seed(persisted_seed);
+            self.gen_and_run_case(strategy, &f)?;
+        }
+        self.rng = old_rng;
+
         while self.successes < self.config.cases {
-            let case = match strategy.new_value(self) {
-                Ok(v) => v,
-                Err(msg) => return Err(TestError::Abort(msg)),
-            };
-            if self.run_one(case, &f)? {
-                self.successes += 1;
+            // Generate a new seed and make an RNG from that so that we know
+            // what seed to persist if this case fails.
+            let seed = <[u32;4] as Rand>::rand(&mut self.rng);
+            self.rng = XorShiftRng::from_seed(seed);
+            let result = self.gen_and_run_case(strategy, &f);
+            if let Err(TestError::Fail(_, ref value)) = result {
+                save_persisted_failure(persist_path.as_ref(), seed, value);
             }
+
+            let _ = result?;
         }
 
+        Ok(())
+    }
+
+    fn gen_and_run_case<S : Strategy, F : Fn (&ValueFor<S>) -> TestCaseResult>
+        (&mut self, strategy: &S, f: &F)
+        -> Result<(), TestError<ValueFor<S>>>
+    {
+        let case = match strategy.new_value(self) {
+            Ok(v) => v,
+            Err(msg) => return Err(TestError::Abort(msg)),
+        };
+        if self.run_one(case, f)? {
+            self.successes += 1;
+        }
         Ok(())
     }
 
@@ -455,8 +734,11 @@ impl TestRunner {
 #[cfg(test)]
 mod test {
     use std::cell::Cell;
+    use std::fs;
 
     use super::*;
+    use strategy::Strategy;
+
 
     #[test]
     fn gives_up_after_too_many_rejections() {
@@ -483,7 +765,10 @@ mod test {
 
     #[test]
     fn test_fail_via_result() {
-        let mut runner = TestRunner::default();
+        let mut runner = TestRunner::new(Config {
+            failure_persistence: FailurePersistence::Off,
+            .. Config::default()
+        });
         let result = runner.run(&(0u32..10u32), |&v| if v < 5 {
             Ok(())
         } else {
@@ -496,12 +781,162 @@ mod test {
 
     #[test]
     fn test_fail_via_panic() {
-        let mut runner = TestRunner::default();
+        let mut runner = TestRunner::new(Config {
+            failure_persistence: FailurePersistence::Off,
+            .. Config::default()
+        });
         let result = runner.run(&(0u32..10u32), |&v| {
             assert!(v < 5, "not less than 5");
             Ok(())
         });
         assert_eq!(Err(TestError::Fail("not less than 5".to_owned(), 5)),
                    result);
+    }
+
+    struct TestPaths {
+        crate_root: &'static Path,
+        lib_root: PathBuf,
+        src_subdir: PathBuf,
+        src_file: PathBuf,
+        subdir_file: PathBuf,
+        misplaced_file: PathBuf,
+    }
+
+    lazy_static! {
+        static ref TEST_PATHS: TestPaths = {
+            let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+            let lib_root = crate_root.join("src");
+            let src_subdir = lib_root.join("strategy");
+            let src_file = lib_root.join("foo.rs");
+            let subdir_file = src_subdir.join("foo.rs");
+            let misplaced_file = crate_root.join("foo.rs");
+            TestPaths {
+                crate_root, lib_root, src_subdir,
+                src_file, subdir_file, misplaced_file
+            }
+        };
+    }
+
+    // This test assumes UNIX-like paths
+    #[cfg(unix)]
+    #[test]
+    fn persistence_file_location_resolved_correctly() {
+        // If off, there is never a file
+        assert_eq!(None, FailurePersistence::Off.resolve(None));
+        assert_eq!(None, FailurePersistence::Off.resolve(
+            Some(&TEST_PATHS.subdir_file)));
+
+        // For direct, we don't care about the source file, and instead always
+        // use whatever is in the config.
+        assert_eq!(Some(Path::new("bar.txt").to_owned()),
+                   FailurePersistence::Direct("bar.txt").resolve(None));
+        assert_eq!(Some(Path::new("bar.txt").to_owned()),
+                   FailurePersistence::Direct("bar.txt").resolve(
+                       Some(&TEST_PATHS.subdir_file)));
+
+        // For WithSource, it should be located under src_subdir if the source
+        // file is available and the configuration is relative. Otherwise, it
+        // is the configuration exactly.
+        assert_eq!(Some(TEST_PATHS.src_subdir.join("bar.txt")),
+                   FailurePersistence::WithSource("bar.txt").resolve(
+                       Some(&TEST_PATHS.subdir_file)));
+        assert_eq!(Some(Path::new("/foo/bar.txt").to_owned()),
+                   FailurePersistence::WithSource("/foo/bar.txt").resolve(
+                       Some(&TEST_PATHS.subdir_file)));
+        assert_eq!(Some(Path::new("bar.txt").to_owned()),
+                   FailurePersistence::WithSource("bar.txt").resolve(None));
+
+        // For WithMain, a file alongside lib.rs or in a subdirectory results
+        // in a file in the same dir as lib.rs...
+        assert_eq!(Some(TEST_PATHS.lib_root.join("bar.txt")),
+                   FailurePersistence::WithMain("bar.txt").resolve(
+                       Some(&TEST_PATHS.subdir_file)));
+        assert_eq!(Some(TEST_PATHS.lib_root.join("bar.txt")),
+                   FailurePersistence::WithMain("bar.txt").resolve(
+                       Some(&TEST_PATHS.src_file)));
+        // ... but if neither lib.rs nor main.rs can be found, it ends up
+        // alongside the source ...
+        assert_eq!(Some(TEST_PATHS.crate_root.join("bar.txt")),
+                   FailurePersistence::WithMain("bar.txt").resolve(
+                       Some(&TEST_PATHS.misplaced_file)));
+        // ... but if the configured path is absolute, the result is also
+        // absolute in both cases ...
+        assert_eq!(Some(Path::new("/foo/bar.txt").to_owned()),
+                   FailurePersistence::WithMain("/foo/bar.txt").resolve(
+                       Some(&TEST_PATHS.src_file)));
+        assert_eq!(Some(Path::new("/foo/bar.txt").to_owned()),
+                   FailurePersistence::WithMain("/foo/bar.txt").resolve(
+                       Some(&TEST_PATHS.misplaced_file)));
+        // ... and if no source is available, we just use the raw path
+        assert_eq!(Some(Path::new("bar.txt").to_owned()),
+                   FailurePersistence::WithMain("bar.txt").resolve(None));
+    }
+
+    #[derive(Clone, Copy, PartialEq)]
+    struct PoorlyBehavedDebug(i32);
+    impl fmt::Debug for PoorlyBehavedDebug {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "\r\n{:?}\r\n", self.0)
+        }
+    }
+
+    #[test]
+    fn failing_cases_persisted_and_reloaded() {
+        const FILE: &'static str = "persistence-test.txt";
+        let _ = fs::remove_file(FILE);
+
+        let max = 10_000_000i32;
+        let input = (0i32..max).prop_map(PoorlyBehavedDebug);
+        let config = Config {
+            failure_persistence: FailurePersistence::Direct(FILE),
+            .. Config::default()
+        };
+
+        // First test with cases that fail above half max, and then below half
+        // max, to ensure we can correctly parse both lines of the persistence
+        // file.
+        let first_sub_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 < max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::Fail("too big".to_owned()))
+                }
+            }).err().expect("didn't fail?")
+        };
+        let first_super_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 >= max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::Fail("too small".to_owned()))
+                }
+            }).err().expect("didn't fail?")
+        };
+        let second_sub_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 < max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::Fail("too big".to_owned()))
+                }
+            }).err().expect("didn't fail?")
+        };
+        let second_super_failure = {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(&input, |v| {
+                if v.0 >= max/2 {
+                    Ok(())
+                } else {
+                    Err(TestCaseError::Fail("too small".to_owned()))
+                }
+            }).err().expect("didn't fail?")
+        };
+
+        assert_eq!(first_sub_failure, second_sub_failure);
+        assert_eq!(first_super_failure, second_super_failure);
     }
 }


### PR DESCRIPTION
A solution to https://github.com/AltSysrq/proptest/issues/21. [How it works](
https://github.com/AltSysrq/proptest/blob/378e430ad926e596f68f7df34d06a478b87541e5/README.md#failure-persistence)

I've taken the approach of making this "just work" by default with options to configure/disable it if desired, since I can't think of any cases where this would actually introduce breakage.

@Centril Any opinions? There's probably some stuff like filenames that might be worth bike-sheding too.