### PR TITLE
Support u128 and i128 behind unstable Cargo.toml flag for nightly users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### New Additions
+
+- Added support for `i128` and `u128`. Since this is an unstable feature in
+  Rust, this is hidden behind the feature `unstable` which you have to
+  explicitly opt into in your `Cargo.toml` file.
+
 ## 0.3.2
 
 ### New Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,13 @@ Hypothesis-like property-based testing and shrinking.
 [badges]
 travis-ci = { repository = "AltSysrq/proptest" }
 
+[features]
+
+default = []
+
+# Enables unstable features of Rust.
+unstable = []
+
 [dependencies]
 bit-set = "0.4.0"
 quick-error = "1.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1357,6 +1357,8 @@
 
 #![deny(missing_docs)]
 
+#![cfg_attr(feature = "unstable", feature(i128_type))]
+
 extern crate bit_set;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate quick_error;

--- a/src/num.rs
+++ b/src/num.rs
@@ -272,6 +272,11 @@ unsigned_integer_bin_search!(u32);
 unsigned_integer_bin_search!(u64);
 unsigned_integer_bin_search!(usize);
 
+#[cfg(feature = "unstable")]
+signed_integer_bin_search!(i128);
+#[cfg(feature = "unstable")]
+unsigned_integer_bin_search!(u128);
+
 macro_rules! float_bin_search {
     ($typ:ident) => {
         #[allow(missing_docs)]


### PR DESCRIPTION
## In this PR

- Added support for `i128` and `u128`. Since this is an unstable feature in
  Rust, this is hidden behind the feature `unstable` which you have to
  explicitly opt into in your `Cargo.toml` file.