### PR TITLE
Fixes compiler errors in unstable tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "AltSysrq/proptest" }
 default = []
 
 # Enables unstable features of Rust.
-unstable = []
+unstable = ["rand/i128_support"]
 
 [dependencies]
 bitflags = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1428,6 +1428,7 @@
 #![deny(missing_docs)]
 
 #![cfg_attr(feature = "unstable", feature(i128_type))]
+#![cfg_attr(feature = "unstable", feature(i128))]
 
 #[macro_use] extern crate bitflags;
 extern crate bit_set;


### PR DESCRIPTION
Hey, thanks for the great library!

I was messing around with it a bit and found that when I ran `cargo test --features unstable` locally, I got a bunch of compiler errors due to `feature(i128_type)` being enabled in the library but not `feature(i128)`, and `feature(i128_support)` not being enabled in the `rand` dependency.

This PR fixes that, once fixed all the unstable tests do still pass. I assume that they used to compile, but things changed and weren't caught cause travis doesn't enable the unstable feature in the nightly tests. I was thinking it'd probably be a good idea to change that so that this wouldn't happen again in the future but haven't yet figured out how to do that.
