### PR TITLE
don't pin dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ default = []
 unstable = ["rand/i128_support"]
 
 [dependencies]
-bitflags = "1.0.1"
-bit-set = "0.4.0"
-quick-error = "1.2.1"
-rand = "0.4.2"
-regex-syntax = "0.4.2"
-lazy_static = "1.0.0"
+bitflags = ">=1.0.1"
+bit-set = ">=0.4.0"
+quick-error = ">=1.2.1"
+rand = ">=0.4.2"
+regex-syntax = ">=0.4.2"
+lazy_static = ">=1.0.0"
 
 [dev-dependencies]
-regex = "0.2.5"
+regex = ">=0.2.5"


### PR DESCRIPTION
Originally I thought this would fix #37 (it doesn't, that was because of regex_generate)

I think it is still considered best practices to not pin dependencies on a library. Let me know if you have other thoughts.