### PR TITLE
Reduce heap allocation in .prop_recursive(..) + make it more ergonomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Potential Breaking Changes
 
+- There is a small chance of breakage if you've relied on the constraints put
+  on type inference by the closure in `leaf.prop_recursive(..)` having a fixed
+  output type. The output type is now any strategy that generates the same type
+  as `leaf`. This change is intended to make working with recursive types a bit
+  easier as you no longer have to use `.boxed()` inside the closure you pass to
+  `.prop_recursive(..)`.
+
 - There is a small chance of breakage wrt. type inference due to the
   introduction of `SizeRange`.
 
@@ -62,6 +69,8 @@
 ### Minor changes
 
 - Relaxed the constraints of `btree_map` removing `'static`.
+
+- Reduced the heap allocation inside `Recursive` somewhat.
 
 ## 0.4.2
 

--- a/src/arbitrary/_std/env.rs
+++ b/src/arbitrary/_std/env.rs
@@ -71,7 +71,7 @@ fn make_utf16_invalid(buf: &mut Vec<u16>, p: usize) {
 #[cfg(target_os = "windows")]
 fn osstring_invalid_string() -> BoxedStrategy<OsString> {
     use std::os::windows::ffi::OsStringExt;
-    let size = 0..::std::u16::MAX as usize;
+    let size = 1..::std::u16::MAX as usize;
     let vec_gen = ::collection::vec(..::std::u16::MAX, size.clone());
     (size, vec_gen).prop_map(|(p, mut sbuf)| {
         // Not quite a uniform distribution due to clamping,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1277,7 +1277,7 @@
 //!               .prop_map(Json::Array),
 //!           prop::collection::hash_map(".*", inner, 0..10)
 //!               .prop_map(Json::Map),
-//!       ].boxed()).boxed()
+//!       ]).boxed()
 //! }
 //! # fn main() { }
 //! ```

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -588,12 +588,11 @@ impl<T : ValueTree + ?Sized> ValueTree for Box<T> {
 /// A boxed `ValueTree`.
 type BoxedVT<T> = Box<ValueTree<Value = T>>;
 
-/// Shorthand for a boxed `Strategy` trait object as produced by
-/// `Strategy::boxed()`.
+/// A boxed `Strategy` trait object as produced by `Strategy::boxed()`.
 #[derive(Debug)]
 pub struct BoxedStrategy<T>(Box<Strategy<Value = BoxedVT<T>>>);
 
-/// Shorthand for a boxed `Strategy` trait object which is also `Sync` and
+/// A boxed `Strategy` trait object which is also `Sync` and
 /// `Send`, as produced by `Strategy::sboxed()`.
 #[derive(Debug)]
 pub struct SBoxedStrategy<T>(Box<Strategy<Value = BoxedVT<T>> + Sync + Send>);

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -367,7 +367,7 @@ pub trait Strategy : fmt::Debug {
     ///       .prop_map(JsonNode::Array),
     ///     prop::collection::hash_map(".*", element, 0..16)
     ///       .prop_map(JsonNode::Map)
-    ///   ].boxed());
+    ///   ]);
     /// # }
     /// ```
     fn prop_recursive<R, F>

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -370,17 +370,16 @@ pub trait Strategy : fmt::Debug {
     ///   ].boxed());
     /// # }
     /// ```
-    fn prop_recursive<
-            F : Fn (Arc<BoxedStrategy<ValueFor<Self>>>)
-                    -> BoxedStrategy<ValueFor<Self>>>
+    fn prop_recursive<R, F>
         (self, depth: u32, desired_size: u32, expected_branch_size: u32, recurse: F)
         -> Recursive<BoxedStrategy<ValueFor<Self>>, F>
-    where Self : Sized + 'static {
-        Recursive {
-            base: Arc::new(self.boxed()),
-            recurse: Arc::new(recurse),
-            depth, desired_size, expected_branch_size,
-        }
+    where
+        Self : Sized + 'static,
+        F : Fn(Arc<BoxedStrategy<ValueFor<Self>>>) -> R,
+        R : Strategy + 'static,
+        R::Value : ValueTree<Value = ValueFor<Self>>
+    {
+        Recursive::new(self, depth, desired_size, expected_branch_size, recurse)
     }
 
     /// Shuffle the contents of the values produced by this strategy.


### PR DESCRIPTION
## Other changes

+ Bugfix in `#[cfg(target_os = "windows")] fn osstring_invalid_string()`. Since this was unreleased it's not included in the CHANGELOG.

+ Some housekeeping (reorganising) + documentation fixes.

## CHANGELOG

### Potential Breaking Changes

- There is a small chance of breakage if you've relied on the constraints put
  on type inference by the closure in `leaf.prop_recursive(..)` having a fixed
  output type. The output type is now any strategy that generates the same type
  as `leaf`. This change is intended to make working with recursive types a bit
  easier as you no longer have to use `.boxed()` inside the closure you pass to
  `.prop_recursive(..)`.

### Minor changes

- Reduced the heap allocation inside `Recursive` somewhat.