### PR TITLE
ArcStrategy (and arc_boxed) + Recursive improvements + housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Unreleased
+
+### New Additions
+
+- Added `ArcStrategy<T>` and `.arc_boxed()` for boxed strategies affording
+  cheap shallow cloning by reference counting (internally using an `Arc`).
+
+### Potential Breaking Changes
+
+- There is a small change of breakage if you've relied on `Recursive` using
+  a `BoxedStrategy` as `Recursive` now internally uses `ArcStrategy<T>`
+  instead as well as expecting a `Fn(ArcStrategy<T>) -> R` instead of
+  `Fn(Arc<BoxedStrategy<T>>) -> R`.
+
+### Minor changes
+
+- Reduced indirections and heap allocations inside `Recursive` somewhat.
+
 ## 0.5.1
 
 ### New Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,21 @@
 ## Unreleased
 
-### New Additions
-
-- Added `ArcStrategy<T>` and `.arc_boxed()` for boxed strategies affording
-  cheap shallow cloning by reference counting (internally using an `Arc`).
-
 ### Potential Breaking Changes
 
 - There is a small change of breakage if you've relied on `Recursive` using
-  a `BoxedStrategy` as `Recursive` now internally uses `ArcStrategy<T>`
-  instead as well as expecting a `Fn(ArcStrategy<T>) -> R` instead of
-  `Fn(Arc<BoxedStrategy<T>>) -> R`.
+  an `Arc<BoxedStrategy<T>>` as `Recursive` now internally uses `BoxedStrategy<T>`
+  instead as well as expecting a `Fn(BoxedStrategy<T>) -> R` instead of
+  `Fn(BoxedStrategy<T>) -> R`. In addition, the type of recursive strategies
+  has changed from `Recursive<BoxedStrategy<T>, F>` to just `Recursive<T, F>`.
 
 ### Minor changes
 
-- Reduced indirections and heap allocations inside `Recursive` somewhat.
+- Reduced indirections and heap allocations inside `Recursive<T, F>` somewhat.
+
+- `BoxedStrategy<T>` and `SBoxedStrategy<T>` now use `Arc` internally instead of
+  using `Box`. While this has marginal overhead, it also reduces the overhead
+  in `Recursive<T, F>`. The upside to this change is also that you can very
+  cheaply clone strategies.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 - Reduced indirections and heap allocations inside `Recursive` somewhat.
 
+### Bug Fixes
+
+- Removed `impl Arbitrary for LocalKeyState` since `LocalKeyState` no longer
+  exists in the nightly compiler.
+
 ## 0.5.1
 
 ### New Additions

--- a/src/arbitrary/_std/thread.rs
+++ b/src/arbitrary/_std/thread.rs
@@ -11,9 +11,6 @@
 
 use std::thread::*;
 
-#[cfg(feature = "unstable")]
-use strategy::*;
-
 use strategy::statics::static_map;
 use option::prob;
 use arbitrary::*;
@@ -61,25 +58,10 @@ arbitrary!([A: 'static + Send + Arbitrary<'a>] JoinHandle<A>,
 );
 */
 
-#[cfg(feature = "unstable")]
-arbitrary!(LocalKeyState,
-    TupleUnion<(W<Just<Self>>, W<Just<Self>>, W<Just<Self>>)>;
-    prop_oneof![
-        Just(LocalKeyState::Uninitialized),
-        Just(LocalKeyState::Valid),
-        Just(LocalKeyState::Destroyed)
-    ]
-);
-
 #[cfg(test)]
 mod test {
     no_panic_test!(
         builder => Builder
-    );
-
-    #[cfg(feature = "unstable")]
-    no_panic_test!(
-        local_key_state => LocalKeyState
     );
 
     /*


### PR DESCRIPTION
## Housekeeping

- Some general house keeping in `test_runner.rs` and `flatten.rs`.

## Unreleased

### New Additions

- Added `ArcStrategy<T>` and `.arc_boxed()` for boxed strategies affording
  cheap shallow cloning by reference counting (internally using an `Arc`).

### Potential Breaking Changes

- There is a small change of breakage if you've relied on `Recursive` using
  a `BoxedStrategy` as `Recursive` now internally uses `ArcStrategy<T>`
  instead as well as expecting a `Fn(ArcStrategy<T>) -> R` instead of
  `Fn(Arc<BoxedStrategy<T>>) -> R`.

### Minor changes

- Reduced indirections and heap allocations inside `Recursive` somewhat.

### Bug Fixes

- Removed `impl Arbitrary for LocalKeyState` since `LocalKeyState` no longer
  exists in the nightly compiler.