### PR TITLE
Separate out the ValueTree of Filter<S, F> into FilterValueTree + reduce cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   `Fn(BoxedStrategy<T>) -> R`. In addition, the type of recursive strategies
   has changed from `Recursive<BoxedStrategy<T>, F>` to just `Recursive<T, F>`.
 
+- `Filter<S, F>` and `statics::Filter<S, F>` no longer implement `ValueTree`.
+  They now delegate this responsibility to the new types `FilterValueTree` and
+  `statics::FilterValueTree`. The risk of breakage is however small.
+
 ### Minor changes
 
 - Reduced indirections and heap allocations inside `Recursive<T, F>` somewhat.
@@ -16,6 +20,9 @@
   using `Box`. While this has marginal overhead, it also reduces the overhead
   in `Recursive<T, F>`. The upside to this change is also that you can very
   cheaply clone strategies.
+
+- Reduced the amount of cloning that `Filter<S, F>` (and the `static::` cousin)
+  does by introducing `FilterValueTree`s.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## Unreleased
+
+### Potential Breaking Changes
+
+- There is a small change of breakage if you've relied on `Recursive` using
+  an `Arc<BoxedStrategy<T>>` as `Recursive` now internally uses `BoxedStrategy<T>`
+  instead as well as expecting a `Fn(BoxedStrategy<T>) -> R` instead of
+  `Fn(BoxedStrategy<T>) -> R`. In addition, the type of recursive strategies
+  has changed from `Recursive<BoxedStrategy<T>, F>` to just `Recursive<T, F>`.
+
+### Minor changes
+
+- Reduced indirections and heap allocations inside `Recursive<T, F>` somewhat.
+
+- `BoxedStrategy<T>` and `SBoxedStrategy<T>` now use `Arc` internally instead of
+  using `Box`. While this has marginal overhead, it also reduces the overhead
+  in `Recursive<T, F>`. The upside to this change is also that you can very
+  cheaply clone strategies.
+
+### Bug Fixes
+
+- Removed `impl Arbitrary for LocalKeyState` since `LocalKeyState` no longer
+  exists in the nightly compiler.
+
 ## 0.5.1
 
 ### New Additions

--- a/src/arbitrary/_std/thread.rs
+++ b/src/arbitrary/_std/thread.rs
@@ -11,9 +11,6 @@
 
 use std::thread::*;
 
-#[cfg(feature = "unstable")]
-use strategy::*;
-
 use strategy::statics::static_map;
 use option::prob;
 use arbitrary::*;
@@ -61,25 +58,10 @@ arbitrary!([A: 'static + Send + Arbitrary<'a>] JoinHandle<A>,
 );
 */
 
-#[cfg(feature = "unstable")]
-arbitrary!(LocalKeyState,
-    TupleUnion<(W<Just<Self>>, W<Just<Self>>, W<Just<Self>>)>;
-    prop_oneof![
-        Just(LocalKeyState::Uninitialized),
-        Just(LocalKeyState::Valid),
-        Just(LocalKeyState::Destroyed)
-    ]
-);
-
 #[cfg(test)]
 mod test {
     no_panic_test!(
         builder => Builder
-    );
-
-    #[cfg(feature = "unstable")]
-    no_panic_test!(
-        local_key_state => LocalKeyState
     );
 
     /*

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -238,6 +238,12 @@ mapfn! {
 #[derive(Debug, Clone, Copy)]
 struct MinSize(usize);
 
+type FilterMinSize<S, Mapper>
+    = statics::Filter<statics::Map<S, Mapper>, MinSize>;
+
+type FilterVTMinSize<VT, Mapper>
+    = statics::FilterValueTree<statics::Map<VT, Mapper>, MinSize>;
+
 impl<T : Eq + Hash> statics::FilterFn<HashSet<T>> for MinSize {
     fn apply(&self, set: &HashSet<T>) -> bool {
         set.len() >= self.0
@@ -250,12 +256,12 @@ opaque_strategy_wrapper! {
     /// Created by the `hash_set()` function in the same module.
     #[derive(Clone, Debug)]
     pub struct HashSetStrategy[<T>][where T : Strategy, ValueFor<T> : Hash + Eq](
-        statics::Filter<statics::Map<VecStrategy<T>, VecToHashSet>, MinSize>)
+        FilterMinSize<VecStrategy<T>, VecToHashSet>)
         -> HashSetValueTree<T::Value>;
     /// `ValueTree` corresponding to `HashSetStrategy`.
     #[derive(Clone, Debug)]
     pub struct HashSetValueTree[<T>][where T : ValueTree, T::Value : Hash + Eq](
-        statics::Filter<statics::Map<VecValueTree<T>, VecToHashSet>, MinSize>)
+        FilterVTMinSize<VecValueTree<T>, VecToHashSet>)
         -> HashSet<T::Value>;
 }
 
@@ -298,12 +304,12 @@ opaque_strategy_wrapper! {
     /// Created by the `btree_set()` function in the same module.
     #[derive(Clone, Debug)]
     pub struct BTreeSetStrategy[<T>][where T : Strategy, ValueFor<T> : Ord](
-        statics::Filter<statics::Map<VecStrategy<T>, VecToBTreeSet>, MinSize>)
+        FilterMinSize<VecStrategy<T>, VecToBTreeSet>)
         -> BTreeSetValueTree<T::Value>;
     /// `ValueTree` corresponding to `BTreeSetStrategy`.
     #[derive(Clone, Debug)]
     pub struct BTreeSetValueTree[<T>][where T : ValueTree, T::Value : Ord](
-        statics::Filter<statics::Map<VecValueTree<T>, VecToBTreeSet>, MinSize>)
+        FilterVTMinSize<VecValueTree<T>, VecToBTreeSet>)
         -> BTreeSet<T::Value>;
 }
 
@@ -349,15 +355,13 @@ opaque_strategy_wrapper! {
     #[derive(Clone, Debug)]
     pub struct HashMapStrategy[<K, V>]
         [where K : Strategy, V : Strategy, ValueFor<K> : Hash + Eq](
-            statics::Filter<statics::Map<VecStrategy<(K,V)>,
-            VecToHashMap>, MinSize>)
+            FilterMinSize<VecStrategy<(K,V)>, VecToHashMap>)
         -> HashMapValueTree<K::Value, V::Value>;
     /// `ValueTree` corresponding to `HashMapStrategy`.
     #[derive(Clone, Debug)]
     pub struct HashMapValueTree[<K, V>]
         [where K : ValueTree, V : ValueTree, K::Value : Hash + Eq](
-            statics::Filter<statics::Map<VecValueTree<TupleValueTree<(K, V)>>,
-            VecToHashMap>, MinSize>)
+            FilterVTMinSize<VecValueTree<TupleValueTree<(K, V)>>, VecToHashMap>)
         -> HashMap<K::Value, V::Value>;
 }
 
@@ -404,15 +408,13 @@ opaque_strategy_wrapper! {
     #[derive(Clone, Debug)]
     pub struct BTreeMapStrategy[<K, V>]
         [where K : Strategy, V : Strategy, ValueFor<K> : Ord](
-            statics::Filter<statics::Map<VecStrategy<(K,V)>,
-            VecToBTreeMap>, MinSize>)
+            FilterMinSize<VecStrategy<(K,V)>, VecToBTreeMap>)
         -> BTreeMapValueTree<K::Value, V::Value>;
     /// `ValueTree` corresponding to `BTreeMapStrategy`.
     #[derive(Clone, Debug)]
     pub struct BTreeMapValueTree[<K, V>]
         [where K : ValueTree, V : ValueTree, K::Value : Ord](
-            statics::Filter<statics::Map<VecValueTree<TupleValueTree<(K, V)>>,
-            VecToBTreeMap>, MinSize>)
+            FilterVTMinSize<VecValueTree<TupleValueTree<(K, V)>>, VecToBTreeMap>)
         -> BTreeMap<K::Value, V::Value>;
 }
 

--- a/src/strategy/recursive.rs
+++ b/src/strategy/recursive.rs
@@ -15,15 +15,15 @@ use strategy::unions::float_to_weight;
 use test_runner::*;
 
 /// Return type from `Strategy::prop_recursive()`.
-pub struct Recursive<B, F> {
-    pub(super) base: Arc<B>,
-    pub(super) recurse: Arc<F>,
-    pub(super) depth: u32,
-    pub(super) desired_size: u32,
-    pub(super) expected_branch_size: u32,
+pub struct Recursive<T, F> {
+    base: BoxedStrategy<T>,
+    recurse: Arc<F>,
+    depth: u32,
+    desired_size: u32,
+    expected_branch_size: u32,
 }
 
-impl<B : fmt::Debug, F> fmt::Debug for Recursive<B, F> {
+impl<T: fmt::Debug, F> fmt::Debug for Recursive<T, F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Recursive")
             .field("base", &self.base)
@@ -35,10 +35,10 @@ impl<B : fmt::Debug, F> fmt::Debug for Recursive<B, F> {
     }
 }
 
-impl<B, F> Clone for Recursive<B, F> {
+impl<T, F> Clone for Recursive<T, F> {
     fn clone(&self) -> Self {
         Recursive {
-            base: Arc::clone(&self.base),
+            base: self.base.clone(),
             recurse: Arc::clone(&self.recurse),
             depth: self.depth,
             desired_size: self.desired_size,
@@ -47,11 +47,11 @@ impl<B, F> Clone for Recursive<B, F> {
     }
 }
 
-impl<T : fmt::Debug + 'static,
-     R : Strategy + 'static,
-     F : Fn(Arc<BoxedStrategy<T>>) -> R>
-Recursive<BoxedStrategy<T>, F>
+impl<T, R, F> Recursive<T, F>
 where
+    T : fmt::Debug + 'static,
+    R : Strategy + 'static,
+    F : Fn(BoxedStrategy<T>) -> R,
     R::Value : ValueTree<Value = T>
 {
     pub(super) fn new<S>
@@ -63,18 +63,18 @@ where
         S::Value : ValueTree<Value = T>
     {
         Self {
-            base: Arc::new(base.boxed()),
+            base: base.boxed(),
             recurse: Arc::new(recurse),
             depth, desired_size, expected_branch_size,
         }
     }
 }
 
-impl<T : fmt::Debug + 'static,
-     R : Strategy + 'static,
-     F : Fn(Arc<BoxedStrategy<T>>) -> R>
-Strategy for Recursive<BoxedStrategy<T>, F>
+impl<T, R, F> Strategy for Recursive<T, F>
 where
+    T : fmt::Debug + 'static,
+    R : Strategy + 'static,
+    F : Fn(BoxedStrategy<T>) -> R,
     R::Value : ValueTree<Value = T>
 {
     type Value = Box<ValueTree<Value = T>>;
@@ -116,10 +116,10 @@ where
             k2 = k2.saturating_mul(u64::from(self.expected_branch_size) * 2);
         }
 
-        let mut strat = Arc::clone(&self.base);
+        let mut strat = self.base.clone();
         while let Some(branch_probability) = branch_probabilities.pop() {
-            let recursed = (self.recurse)(Arc::clone(&strat));
-            let recursive_choice = Arc::new(recursed.boxed());
+            let recursed = (self.recurse)(strat.clone());
+            let recursive_choice = recursed.boxed();
             let non_recursive_choice = strat;
             // Clamp the maximum branch probability to 0.9 to ensure we can
             // generate non-recursive cases reasonably often.
@@ -130,7 +130,7 @@ where
                 weight_leaf => non_recursive_choice,
                 weight_branch => recursive_choice,
             ];
-            strat = Arc::new(branch.boxed());
+            strat = branch.boxed();
         }
 
         strat.new_value(runner)


### PR DESCRIPTION
This will most likely merge conflict with my other PR unfortunately in the CHANGELOG I think.

## Unreleased

### Potential Breaking Changes

- `Filter<S, F>` and `statics::Filter<S, F>` no longer implement `ValueTree`.
  They now delegate this responsibility to the new types `FilterValueTree` and
  `statics::FilterValueTree`. The risk of breakage is however small.

### Minor changes

- Reduced the amount of cloning that `Filter<S, F>` (and the `static::` cousin)
  does by introducing `FilterValueTree`s.