### PR TITLE
Update regex-syntax dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ version = "1.2.1"
 optional = true
 
 [dependencies.regex-syntax]
-version = "0.4.2"
+version = "0.6.0"
 optional = true
 
 [dependencies.bit-set]


### PR DESCRIPTION
I realized we'd have to update our regex-syntax dependency if we were ever planning on pulling in the upcoming no_std + alloc regex capabilities, so here we have a switch from the old, pinned regex-syntax to a more recent version.

The most obvious difference is that in the updated regex-syntax, the crate provides a higher-order representation that is further digested than the raw AST.   It accomplishes useful things like resolving the effects of case insensitivity by modifying the character/byte classes presented.

The largest implication, AFAICT, from using this more digested data source is that we lose some ability to provide custom behavior for special-case character classes (e.g. `AnyCharNoNL`), without doing some significantly deeper inspection of our own. As a result, the prior characteristic of manually overweighting certain character ranges in our generated output has been dropped.