### PR TITLE
Change regression file line parse

### DIFF
--- a/src/test_runner/failure_persistence/file.rs
+++ b/src/test_runner/failure_persistence/file.rs
@@ -237,10 +237,10 @@ fn parse_seed_line(mut line: String, path: &Path, lineno: usize)
         line.truncate(comment_start);
     }
 
-    // Split by whitespace and ignore empty lines:
-    let parts = line.trim().split(char::is_whitespace).collect::<Vec<_>>();
-    let len = parts.len();
-    if len > 0 {
+    if line.len() > 0 {
+        // Split by whitespace and ignore empty lines:
+        let parts = line.trim().split(char::is_whitespace).collect::<Vec<_>>();
+        let len = parts.len();
         // "xs" stands for "XorShift".
         if parts[0] == "xs" && len == 5 {
             // Parse using the chosen one:


### PR DESCRIPTION
Split will always leave at least one part, even if there is no delimeter. This corrects the logic to use the string's length to check for emptiness before trying to split it.

(PR created with the in-browser GitHub file editor)

Fixes #63 