### PR TITLE
Make StringParam constructible

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -31,7 +31,7 @@ use test_runner::*;
 /// Wraps the regex that forms the `Strategy` for `String` so that a sensible
 /// `Default` can be given. The default is a string of non-control characters.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct StringParam(&'static str);
+pub struct StringParam(pub &'static str);
 
 impl From<StringParam> for &'static str {
     fn from(x: StringParam) -> Self { x.0 }


### PR DESCRIPTION
Attempting to construct a StringParam from a regex pattern would lead to a compiler error with the message "constructor is not visible here due to private fields". The StringParam's sole field needs to be made public to allow external code to construct a StringParam to be passed to any_with::&lt;String&gt;.