### PR TITLE
proptest-derive: cleanup + improved documentation

### DIFF
--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -34,5 +34,5 @@ compiletest_rs = { version = "0.3.3", features = ["tmp"] }
 [dependencies]
 proc-macro2 = "0.4"
 
-syn = { version = "0.14.5", features = ["visit", "extra-traits", "full"] }
+syn = { version = "0.15.17", features = ["visit", "extra-traits", "full"] }
 quote = "0.6"

--- a/proptest-derive/src/derive.rs
+++ b/proptest-derive/src/derive.rs
@@ -24,7 +24,7 @@ use ast::*;
 //==============================================================================
 
 pub fn impl_proptest_arbitrary(ast: DeriveInput) -> TokenStream {
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     let result = derive_proptest_arbitrary(&mut ctx, ast);
     match (result, ctx.check()) {
         (Ok(derive), Ok(())) => derive,

--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Provides error messages and some checkers
+//! Provides error messages and some checkers.
 
 use proc_macro2::TokenStream;
 
@@ -131,26 +131,44 @@ pub fn if_weight_present(ctx: Ctx, attrs: &ParsedAttributes, item: &str) {
 
 use std::fmt::Display;
 
+/// Denotes that a fatal error happened in dealing somewhere in the
+/// procedural macro pipeline. A fatal error is different from a
+/// normal error in the sense that it halts progress in the macro
+/// immediately instead of allowing other errors to be accumulated.
 #[derive(Debug)]
 pub struct Fatal;
+
+/// The return type of a possibly fatal computation in the macro.
 pub type DeriveResult<T> = Result<T, Fatal>;
+
+/// A mutable view / shorthand for the context.
+/// Prefer this type over `Context` in functions.
 pub type Ctx<'ctx> = &'ctx mut Context;
 
+/// The context / environment that the macro is operating in.
+/// Right now, it simply tracks all the errors collected during
+/// the running of the macro.
 #[derive(Default)]
 pub struct Context {
     errors: Vec<String>,
 }
 
 impl Context {
+    /// Add a non-fatal error to the context.
     pub fn error<T: Display>(&mut self, msg: T) {
         self.errors.push(msg.to_string());
     }
 
+    /// Add an error to the context and procuce and produce an erroring
+    /// computation that will halt the macro.
     pub fn fatal<T: Display, A>(&mut self, msg: T) -> DeriveResult<A> {
         self.error(msg);
         Err(Fatal)
     }
 
+    /// Consume the context and if there were any errors,
+    /// emit `compile_error!(..)` such that the crate using
+    /// `#[derive(Arbitrary)]` will fail to compile.
     pub fn check(mut self) -> Result<(), TokenStream> {
         fn compile_error(msg: &str) -> TokenStream {
             quote! {
@@ -177,6 +195,8 @@ impl Context {
 // Messages
 //==============================================================================
 
+/// Produce an error string with the error `$code` which corresponds
+/// to the given `$message`.
 macro_rules! mk_err_msg {
     ($code: ident, $msg: expr) => {
         concat!(

--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -188,7 +188,7 @@ macro_rules! mk_err_msg {
     }
 }
 
-/// A macro constructing errors that do not halt compilation immediately.
+/// A macro constructing errors that do halt compilation immediately.
 macro_rules! fatal {
     ($error: ident, $code: ident, $msg: expr) => {
         pub fn $error<T>(ctx: Ctx) -> DeriveResult<T> {
@@ -203,7 +203,7 @@ macro_rules! fatal {
     };
 }
 
-/// A macro constructing fatal errors that do halt compilation immediately.
+/// A macro constructing fatal errors that do not halt compilation immediately.
 macro_rules! error {
     ($error: ident, $code: ident, $msg: expr) => {
         pub fn $error(ctx: Ctx) {

--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -136,17 +136,12 @@ pub struct Fatal;
 pub type DeriveResult<T> = Result<T, Fatal>;
 pub type Ctx<'ctx> = &'ctx mut Context;
 
+#[derive(Default)]
 pub struct Context {
     errors: Vec<String>,
 }
 
 impl Context {
-    pub fn new() -> Self {
-        Self {
-            errors: Vec::new(),
-        }
-    }
-
     pub fn error<T: Display>(&mut self, msg: T) {
         self.errors.push(msg.to_string());
     }

--- a/proptest-derive/src/use_tracking.rs
+++ b/proptest-derive/src/use_tracking.rs
@@ -191,7 +191,7 @@ fn matches_prj_tyvar(ut: &mut UseTracker, tpath: &syn::TypePath) -> bool {
         false
     } else {
         // true => $tyvar :: $projection
-        return !path.global() && segs.len() == 2
+        return !util::path_is_global(path) && segs.len() == 2
             && ut.has_tyvar(&segs[0].ident)
             && segs[0].arguments.is_empty()
             && segs[1].arguments.is_empty();

--- a/proptest-derive/src/util.rs
+++ b/proptest-derive/src/util.rs
@@ -115,9 +115,15 @@ pub fn is_phantom_data(path: &syn::Path) -> bool {
 /// Extracts a simple non-global path of length 1.
 pub fn extract_simple_path(path: &syn::Path) -> Option<&syn::Ident> {
     match_singleton(&path.segments)
-        .filter(|f| !path.global() && f.arguments.is_empty())
+        .filter(|f| !path_is_global(path) && f.arguments.is_empty())
         .map(|f| &f.ident)
 }
+
+/// Does the path have a leading `::`?
+pub fn path_is_global(path: &syn::Path) -> bool {
+    path.leading_colon.is_some()
+}
+
 //==============================================================================
 // General Rust utilities:
 //==============================================================================

--- a/proptest-derive/src/void.rs
+++ b/proptest-derive/src/void.rs
@@ -15,7 +15,7 @@
 //!
 //! Any analysis we perform here is therefore incomplete but sound.
 //! That is, if we state that a type is uninhabited, it is so for sure.
-//! But we can't state thta all uninhabited types are uninhabited.
+//! But we can't state that all uninhabited types are uninhabited.
 
 use syn::{self, visit};
 


### PR DESCRIPTION
Depends on #100.

This is mainly just documentation changes + fixes.
A small change in `error.rs` is to `#[derive(Default)]` instead of having `Context::new`.