### PR TITLE
remove the nightly requirement for lazy_static on `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,7 @@ default = ["std", "fork", "timeout", "bit-set"]
 # Enables unstable features of Rust.
 unstable = ["rand/i128_support"]
 
-# Required for no_std usage thanks to lazy_static's
-# dependency on the spin crate, which is nightly-only
-# for no_std.
-nightly = ["lazy_static/spin_no_std"]
+nightly = []
 
 # Enables the use of standard-library dependent feature
 std = ["rand/std", "byteorder/std",
@@ -59,8 +56,9 @@ bitflags = "1.0.1"
 # optional = true
 
 [dependencies.lazy_static]
-version = "1.0.0"
+version = "1.2.0"
 default-features = false
+features = ["spin_no_std"]
 
 [dependencies.num-traits]
 version = "0.2.2"


### PR DESCRIPTION
thanks to rust-lang-nursery/lazy-static.rs#130, lazy-static now works on stable with `no_std`

nightly is still required for `alloc` though, so this isn't `no_std` proptest on stable yet