### PR TITLE
Expose TestRunner::partial_clone publicly

### DIFF
--- a/src/test_runner/runner.rs
+++ b/src/test_runner/runner.rs
@@ -282,7 +282,7 @@ impl TestRunner {
     /// Create a fresh `TestRunner` with the same config and global counters as
     /// this one, but with local state reset and an independent `Rng` (but
     /// deterministic).
-    pub(crate) fn partial_clone(&mut self) -> Self {
+    pub fn partial_clone(&mut self) -> Self {
         TestRunner {
             config: self.config.clone(),
             successes: 0,


### PR DESCRIPTION
`test_runner::runner::partial_clone` is currently public within the proptest crate only. Making it publicly available outside the crate would be beneficial.
It is useful, for instance, when multiple test runners are required within a test, and these are to be deterministically derived from a single persistent failure saved in `proptest-regressions`. 

Does this align with the design philosophy and intended API surface of the library? Otherwise, if better suited, I would propose an optional `TestRng` argument for instantiating a new `Test_runner::runner::TestRunner`, or some equivalent of this.