### PR TITLE
Fix a type mismatch in the date parser example

### DIFF
--- a/book/src/proptest/getting-started.md
+++ b/book/src/proptest/getting-started.md
@@ -250,7 +250,7 @@ $ git add proptest-regressions
 ```rust,ignore
 #[test]
 fn test_october_first() {
-    assert_eq!(Some(0, 10, 1), parse_date("0000-10-01"));
+    assert_eq!(Some((0, 10, 1)), parse_date("0000-10-01"));
 }
 ```
 

--- a/book/src/proptest/getting-started.md
+++ b/book/src/proptest/getting-started.md
@@ -58,7 +58,7 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn doesnt_crash(s in "\\PC*") {
-        parse_date(s);
+        parse_date(&s);
     }
 }
 ```
@@ -141,7 +141,7 @@ proptest! {
 
     #[test]
     fn parses_all_valid_dates(s in "[0-9]{4}-[0-9]{2}-[0-9]{2}") {
-        parse_date(s).unwrap();
+        parse_date(&s).unwrap();
     }
 }
 ```

--- a/proptest/README.md
+++ b/proptest/README.md
@@ -293,7 +293,7 @@ $ git add proptest-regressions
 ```rust,ignore
 #[test]
 fn test_october_first() {
-    assert_eq!(Some(0, 10, 1), parse_date("0000-10-01"));
+    assert_eq!(Some((0, 10, 1)), parse_date("0000-10-01"));
 }
 ```
 

--- a/proptest/README.md
+++ b/proptest/README.md
@@ -103,7 +103,7 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn doesnt_crash(s in "\\PC*") {
-        parse_date(s);
+        parse_date(&s);
     }
 }
 ```
@@ -184,7 +184,7 @@ proptest! {
 
     #[test]
     fn parses_all_valid_dates(s in "[0-9]{4}-[0-9]{2}-[0-9]{2}") {
-        parse_date(s).unwrap();
+        parse_date(&s).unwrap();
     }
 }
 ```

--- a/proptest/examples/dateparser_v1.rs
+++ b/proptest/examples/dateparser_v1.rs
@@ -32,8 +32,8 @@ fn parse_date(s: &str) -> Option<(u32, u32, u32)> {
 
 // NB We omit #[test] on these functions so that main() can call them.
 proptest! {
-    fn doesnt_crash(ref s in "\\PC*") {
-        parse_date(s);
+    fn doesnt_crash(s in "\\PC*") {
+        parse_date(&s);
     }
 }
 

--- a/proptest/examples/dateparser_v2.rs
+++ b/proptest/examples/dateparser_v2.rs
@@ -37,12 +37,12 @@ fn parse_date(s: &str) -> Option<(u32, u32, u32)> {
 
 // NB We omit #[test] on these functions so that main() can call them.
 proptest! {
-    fn doesnt_crash(ref s in "\\PC*") {
-        parse_date(s);
+    fn doesnt_crash(s in "\\PC*") {
+        parse_date(&s);
     }
 
-    fn parses_all_valid_dates(ref s in "[0-9]{4}-[0-9]{2}-[0-9]{2}") {
-        parse_date(s).unwrap();
+    fn parses_all_valid_dates(s in "[0-9]{4}-[0-9]{2}-[0-9]{2}") {
+        parse_date(&s).unwrap();
     }
 
     fn parses_date_back_to_original(y in 0u32..10_000,


### PR DESCRIPTION
I got this when trying to follow the guide:

    error[E0308]: mismatched types
      --> src/lib.rs:32:24
       |
    32 |             parse_date(s);
       |                        ^
       |                        |
       |                        expected &str, found struct `std::string::String`
       |                        help: consider borrowing here: `&s`
      1 pub fn parse_date(s: &str) -> Option<(u32, u32, u32)> {$                             | 43 //-$
       |
       = note: expected type `&str`
                  found type `std::string::String`