### PR TITLE
Avoid a broken relative rustdoc link to Arbitrary

### DIFF
--- a/proptest/src/arbitrary/mod.rs
+++ b/proptest/src/arbitrary/mod.rs
@@ -7,8 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Defines the [`Arbitrary`] trait and related free functions
-//! and type aliases. See the trait for more information.
+//! Defines the `Arbitrary` trait and related free functions
+//! and type aliases.
+//!
+//! See the [`Arbitrary`] trait for more information.
 //!
 //! [`Arbitrary`]: trait.Arbitrary.html
 


### PR DESCRIPTION
In [1] the short description of the "arbitrary" module contains a broken
relative link to the Arbitrary trait.  In [2] the link works fine.  This
workarounds the problem by removing the link from the short description
(by pushing it down).

[1] https://altsysrq.github.io/rustdoc/proptest/0.9.0/proptest/index.html#modules
[2] https://altsysrq.github.io/rustdoc/proptest/0.9.0/proptest/arbitrary/index.html