### PR TITLE
Remove requirement on spin crate.

### DIFF
--- a/book/src/proptest/no-std.md
+++ b/book/src/proptest/no-std.md
@@ -15,7 +15,7 @@ default-features = false
 # alloc: Use the `alloc` crate directly. Proptest has a hard requirement on
 # memory allocation, so either this or `std` is needed.
 # unstable: Enable use of nightly-only compiler features.
-features = ["alloc", "unstable"]
+features = ["no_std", "alloc", "unstable"]
 ```
 
 Some APIs are not available in the `no_std` build. This includes functionality

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -59,6 +59,10 @@ atomic64bit = []
 # passed (see https://github.com/AltSysrq/proptest/issues/124).
 break-dead-code = []
 
+# Enables support for running without std. Be sure to turn off the default
+# features to use this.
+no_std = ["lazy_static/spin_no_std"]
+
 [dependencies]
 bitflags = "1.0.1"
 
@@ -69,7 +73,6 @@ bitflags = "1.0.1"
 [dependencies.lazy_static]
 version = "1.2"
 default-features = false
-features = ["spin_no_std"]
 
 [dependencies.num-traits]
 version = "0.2.2"

--- a/proptest/gen-docs.sh
+++ b/proptest/gen-docs.sh
@@ -10,7 +10,7 @@ set -eux
 if test "$1" = "nostd"; then
     crate=proptest-nostd
     cargo='cargo +nightly'
-    cargoflags='--no-default-features --features=alloc,unstable'
+    cargoflags='--no-default-features --features=no_std,alloc,unstable'
 else
     crate=proptest
     cargo=cargo


### PR DESCRIPTION
This removes the hard requirement on the `spin_no_std` feature of `lazy_static`.

Cargo uses proptest, but it is also part of the rustc workspace. We would prefer to not include `spin` in rustc, so we need a way to turn it off.

I'm not sure how to test this does what is intended.  This is also just a rough stab on how it could work, any other way to disable it would be fine.