### PR TITLE
Support deriving Arbitrary for structs with more than 10 fields

### DIFF
--- a/proptest-derive/tests/misc.rs
+++ b/proptest-derive/tests/misc.rs
@@ -67,6 +67,7 @@ enum Quux {
     },
 }
 
+
 #[test]
 fn asserting_arbitrary() {
     fn assert_arbitrary<T: Arbitrary>() {}

--- a/proptest-derive/tests/struct.rs
+++ b/proptest-derive/tests/struct.rs
@@ -1,0 +1,120 @@
+// Copyright 2019 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use proptest::prelude::Arbitrary;
+use proptest_derive::Arbitrary;
+
+#[derive(Debug, Arbitrary)]
+struct T1 {
+    f1: u8
+}
+
+#[derive(Debug, Arbitrary)]
+struct T10 {
+    f1: char,
+    f2: String,
+    f3: u8,
+    f4: u16,
+    f5: u32,
+    f6: u64,
+    f7: u128,
+    f8: f32,
+    f9: f64,
+    f10: bool,
+}
+
+#[derive(Debug, Arbitrary)]
+struct T11 {
+    f1: char,
+    f2: String,
+    f3: u8,
+    f4: u16,
+    f5: u32,
+    f6: u64,
+    f7: u128,
+    f8: f32,
+    f9: f64,
+    f10: bool,
+    f11: char,
+}
+
+#[derive(Debug, Arbitrary)]
+struct T13 {
+    f1: char,
+    f2: String,
+    f3: u8,
+    f4: u16,
+    f5: u32,
+    f6: u64,
+    f7: u128,
+    f8: f32,
+    f9: f64,
+    f10: bool,
+    f11: char,
+    f12: String,
+    f13: u8,
+}
+
+#[derive(Debug, Arbitrary)]
+struct T19 {
+    f1: char,
+    f2: String,
+    f3: u8,
+    f4: u16,
+    f5: u32,
+    f6: u64,
+    f7: u128,
+    f8: f32,
+    f9: f64,
+    f10: bool,
+    f11: char,
+    f12: String,
+    f13: u8,
+    f14: u16,
+    f15: u32,
+    f16: u64,
+    f17: u128,
+    f18: f32,
+    f19: f64,
+}
+
+#[derive(Debug, Arbitrary)]
+struct T20 {
+    f1: char,
+    f2: String,
+    f3: u8,
+    f4: u16,
+    f5: u32,
+    f6: u64,
+    f7: u128,
+    f8: f32,
+    f9: f64,
+    f10: bool,
+    f11: char,
+    f12: String,
+    f13: u8,
+    f14: u16,
+    f15: u32,
+    f16: u64,
+    f17: u128,
+    f18: f32,
+    f19: f64,
+    f20: bool
+}
+
+#[test]
+fn asserting_arbitrary() {
+    fn assert_arbitrary<T: Arbitrary>() {}
+
+    assert_arbitrary::<T1>();
+    assert_arbitrary::<T10>();
+    assert_arbitrary::<T11>();
+    assert_arbitrary::<T13>();
+    assert_arbitrary::<T19>();
+    assert_arbitrary::<T20>();
+}


### PR DESCRIPTION
This change makes it possible to implement Arbitrary for structs having more than 10 fields. I added a test in `proptest-derive/tests/misc.rs` that illustrates the problem. The struct `MoreThanTenFields` fails to compile with master today with the following error:

```
error[E0277]: the trait bound `(_IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any): _IMPL_ARBITRARY_FOR_Foo::_proptest::strategy::Strategy` is not satisfied
  --> proptest-derive/tests/misc.rs:70:24
   |
70 | #[derive(Clone, Debug, Arbitrary)]
   |                        ^^^^^^^^^ the trait `_IMPL_ARBITRARY_FOR_Foo::_proptest::strategy::Strategy` is not implemented for `(_IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any)`
   |
   = note: required because of the requirements on the impl of `_IMPL_ARBITRARY_FOR_Foo::_proptest::strategy::Strategy` for `_IMPL_ARBITRARY_FOR_Foo::_proptest::strategy::Map<(_IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any, _IMPL_ARBITRARY_FOR_Foo::_proptest::bool::Any), fn((bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool)) -> MoreThanTenFields>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: Could not compile `proptest-derive`.
```
The error is due to the fact that struct fields are represented as a tuple and `proptest/src/arbitrary/tuples.rs` implements Arbitrary for tuples up to 10 elements.

This change represent structs with more than 10 fields as nested tuples of up to 10 fields, so that the code generated for the test ends up being:

```
cargo rustc --test misc --  -Z unstable-options --pretty=expanded

#[allow(non_upper_case_globals)]
const _IMPL_ARBITRARY_FOR_MoreThanTenFields: () =
    {
        extern crate proptest as _proptest;
        impl _proptest::arbitrary::Arbitrary for MoreThanTenFields {
            type
            Parameters
            =
            (<bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             <bool as _proptest::arbitrary::Arbitrary>::Parameters,
             (<bool as _proptest::arbitrary::Arbitrary>::Parameters,
              <bool as _proptest::arbitrary::Arbitrary>::Parameters));
            type
            Strategy
            =
            _proptest::strategy::Map<((<bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       <bool as
                                       _proptest::arbitrary::Arbitrary>::Strategy,
                                       (<bool as
                                        _proptest::arbitrary::Arbitrary>::Strategy,
                                        <bool as
                                        _proptest::arbitrary::Arbitrary>::Strategy))),
                                     fn((bool, bool, bool, bool, bool, bool,
                                         bool, bool, bool, (bool, bool)))
                                         -> Self>;
            fn arbitrary_with(_top: Self::Parameters) -> Self::Strategy {
                {
                    let (param_0, param_1, param_2, param_3, param_4, param_5,
                         param_6, param_7, param_8, (param_9, param_10)) =
                        _top;
                    _proptest::strategy::Strategy::prop_map((_proptest::arbitrary::any_with::<bool>(param_0),
                                                             _proptest::arbitrary::any_with::<bool>(param_1),
                                                             _proptest::arbitrary::any_with::<bool>(param_2),
                                                             _proptest::arbitrary::any_with::<bool>(param_3),
                                                             _proptest::arbitrary::any_with::<bool>(param_4),
                                                             _proptest::arbitrary::any_with::<bool>(param_5),
                                                             _proptest::arbitrary::any_with::<bool>(param_6),
                                                             _proptest::arbitrary::any_with::<bool>(param_7),
                                                             _proptest::arbitrary::any_with::<bool>(param_8),
                                                             (_proptest::arbitrary::any_with::<bool>(param_9),
                                                              _proptest::arbitrary::any_with::<bool>(param_10))),
                                                            |(tmp_0, tmp_1,
                                                              tmp_2, tmp_3,
                                                              tmp_4, tmp_5,
                                                              tmp_6, tmp_7,
                                                              tmp_8,
                                                              (tmp_9,
                                                               tmp_10))|
                                                                MoreThanTenFields{a:
                                                                                      tmp_0,
                                                                                  b:
                                                                                      tmp_1,
                                                                                  c:
                                                                                      tmp_2,
                                                                                  d:
                                                                                      tmp_3,
                                                                                  e:
                                                                                      tmp_4,
                                                                                  f:
                                                                                      tmp_5,
                                                                                  g:
                                                                                      tmp_6,
                                                                                  h:
                                                                                      tmp_7,
                                                                                  i:
                                                                                      tmp_8,
                                                                                  j:
                                                                                      tmp_9,
                                                                                  k:
                                                                                      tmp_10,})
                }
            }
        }
    };
```

I feel like I should conclude this saying that while the fix seems straightforward, this is something I came up with 10 minutes into trying to use proptest for the first time, so apologies if I'm missing something :)