### PR TITLE
Fix `Arbitrary` derivation for variants with size increasing by one

### DIFF
--- a/proptest-derive/src/derive.rs
+++ b/proptest-derive/src/derive.rs
@@ -540,11 +540,7 @@ fn variant_no_explicit_strategy<C>(
             ctor
         } else {
             let pref = acc.add_param(params_ty);
-            if pref + 1 == count {
-                ctor
-            } else {
-                extract_all(ctor, count, FromReg::Num(pref))
-            }
+            extract_all(ctor, count, FromReg::Num(pref))
         },
     ))
 }

--- a/proptest-derive/tests/enum.rs
+++ b/proptest-derive/tests/enum.rs
@@ -452,6 +452,25 @@ enum SameType {
     B(usize),
 }
 
+#[derive(Arbitrary, Debug)]
+enum OneTwo {
+    One(u8),
+    Two(u8, u8),
+}
+
+#[derive(Arbitrary, Debug)]
+enum ZeroOneTwo {
+    Zero,
+    One(u8),
+    Two(u8, u8),
+}
+
+#[derive(Arbitrary, Debug)]
+enum Nested {
+    First(SameType),
+    Second(ZeroOneTwo, OneTwo)
+}
+
 #[test]
 fn asserting_arbitrary() {
     fn assert_arbitrary<T: Arbitrary>() {}
@@ -483,4 +502,7 @@ fn asserting_arbitrary() {
     assert_arbitrary::<T25>();
     assert_arbitrary::<Alan>();
     assert_arbitrary::<SameType>();
+    assert_arbitrary::<OneTwo>();
+    assert_arbitrary::<ZeroOneTwo>();
+    assert_arbitrary::<Nested>();
 }


### PR DESCRIPTION
Fixes #141.
Fixes #146.