### PR TITLE
Update to rand 0.7

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Breaking Changes
+
+- The version of the `rand` crate has been increased to 0.7.
+
 ## 0.9.5
 
 ### Bug Fixes

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -92,15 +92,15 @@ version = "0.5.0"
 optional = true
 
 [dependencies.rand]
-version = "0.6"
+version = "0.7"
 default-features = false
-features = ["alloc", "i128_support"]
+features = ["alloc"]
 
 [dependencies.rand_xorshift]
-version = "0.1"
+version = "0.2"
 
 [dependencies.rand_chacha]
-version = "0.1"
+version = "0.2"
 
 [dependencies.byteorder]
 version = "1.2.3"


### PR DESCRIPTION
The primary change is due to `rand`'s new error handling. With `rand` 0.7, the `rand::Error` type now contains either a boxed `Error` (when `std` is available) or a `NonZeroU32` (in `no_std` cases). As a result, I've introduced a new `PassThroughExhaustedError` type. When `std` is available, the implementation creates a `rand::Error` by boxing a `PassThroughExhaustedError`, while in `no_std` cases, it uses an error code representing the error.

Fixes #168.