### PR TITLE
Add support for hardware entropy source on x86-64.

### DIFF
--- a/book/src/proptest/no-std.md
+++ b/book/src/proptest/no-std.md
@@ -23,10 +23,12 @@ which necessarily needs `std` such as failure persistence and forking, as well
 as features depending on other crates which do not support `no_std` usage, such
 as regex support.
 
-The `no_std` build does not have access to an entropy source. As a result,
-every `TestRunner` (i.e., every `#[test]` when using the `proptest!` macro)
-uses a single hard-coded seed. For complex inputs, it may be a good idea to
-increase the number of test cases to compensate. The hard-coded seed is not
+The `no_std` build may not have access to an entropy source (one exception are
+x86-64 machines that support rdrand, in this case the library can be compiled
+with the `hardware-rng` feature to get random numbers). If no entropy source is
+available, every `TestRunner` (i.e., every `#[test]` when using the `proptest!`
+macro) uses a single hard-coded seed. For complex inputs, it may be a good idea
+to increase the number of test cases to compensate. The hard-coded seed is not
 contractually guaranteed and may change between Proptest releases without
 notice.
 

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -41,6 +41,9 @@ std = ["rand/std", "byteorder/std", "lazy_static",
 #alloc = ["hashmap_core"]
 alloc = []
 
+# Use a hardware random number generator (instead of static seed) for x86 no_std targets
+hardware-rng = ["x86"]
+
 # Enables use of the "fork" feature.
 #
 # Requires std.
@@ -113,6 +116,10 @@ default-features = false
 
 [dependencies.tempfile]
 version = "3.0"
+optional = true
+
+[dependencies.x86]
+version = "0.28.0"
 optional = true
 
 [dev-dependencies]

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -361,8 +361,62 @@ impl TestRng {
                 },
             }
         }
+        #[cfg(all(not(feature = "std"), any(target_arch = "x86", target_arch = "x86_64"), feature = "hardware-rng"))]
+        {
+            return Self::hardware_rng(algorithm);
+        }
         #[cfg(not(feature = "std"))]
-        Self::deterministic_rng(algorithm)
+        {
+            return Self::deterministic_rng(algorithm);
+        }
+    }
+
+    const SEED_FOR_XOR_SHIFT: [u8; 16] = [
+        0xf4, 0x16, 0x16, 0x48, 0xc3, 0xac, 0x77, 0xac, 0x72, 0x20,
+        0x0b, 0xea, 0x99, 0x67, 0x2d, 0x6d,
+    ];
+
+    const SEED_FOR_CHA_CHA: [u8; 32] = [
+        0xf4, 0x16, 0x16, 0x48, 0xc3, 0xac, 0x77, 0xac, 0x72, 0x20,
+        0x0b, 0xea, 0x99, 0x67, 0x2d, 0x6d, 0xca, 0x9f, 0x76, 0xaf,
+        0x1b, 0x09, 0x73, 0xa0, 0x59, 0x22, 0x6d, 0xc5, 0x46, 0x39,
+        0x1c, 0x4a,
+    ];
+
+    /// Returns a `TestRng` with a seed generated with the
+    /// RdRand instruction on x86 machines.
+    ///
+    /// This is useful in `no_std` scenarios on x86 where we don't
+    /// have a random number infrastructure but the `rdrand` instruction is
+    /// available.
+    #[cfg(all(not(feature = "std"), any(target_arch = "x86", target_arch = "x86_64"), feature = "hardware-rng"))]
+    pub fn hardware_rng(algorithm: RngAlgorithm) -> Self {
+        use x86::random::{rdrand_slice, RdRand};
+
+        Self::from_seed_internal(match algorithm {
+            RngAlgorithm::XorShift => {
+                // Initialize to a sane seed just in case
+                let mut seed: [u8; 16] = TestRng::SEED_FOR_XOR_SHIFT;
+                unsafe {
+                    let r = rdrand_slice(&mut seed);
+                    debug_assert!(r, "hardware_rng should only be called on machines with support for rdrand");
+                }
+                Seed::XorShift(seed)
+            },
+            RngAlgorithm::ChaCha => {
+                // Initialize to a sane seed just in case
+                let mut seed: [u8; 32] = TestRng::SEED_FOR_CHA_CHA;
+                unsafe {
+                    let r = rdrand_slice(&mut seed);
+                    debug_assert!(r, "hardware_rng should only be called on machines with support for rdrand");
+                }
+                Seed::ChaCha(seed)
+            },
+            RngAlgorithm::PassThrough => {
+                panic!("deterministic RNG not available for PassThrough")
+            }
+            RngAlgorithm::_NonExhaustive => unreachable!(),
+        })
     }
 
     /// Returns a `TestRng` with a particular hard-coded seed.
@@ -381,16 +435,8 @@ impl TestRng {
     /// issues.
     pub fn deterministic_rng(algorithm: RngAlgorithm) -> Self {
         Self::from_seed_internal(match algorithm {
-            RngAlgorithm::XorShift => Seed::XorShift([
-                0xf4, 0x16, 0x16, 0x48, 0xc3, 0xac, 0x77, 0xac, 0x72, 0x20,
-                0x0b, 0xea, 0x99, 0x67, 0x2d, 0x6d,
-            ]),
-            RngAlgorithm::ChaCha => Seed::ChaCha([
-                0xf4, 0x16, 0x16, 0x48, 0xc3, 0xac, 0x77, 0xac, 0x72, 0x20,
-                0x0b, 0xea, 0x99, 0x67, 0x2d, 0x6d, 0xca, 0x9f, 0x76, 0xaf,
-                0x1b, 0x09, 0x73, 0xa0, 0x59, 0x22, 0x6d, 0xc5, 0x46, 0x39,
-                0x1c, 0x4a,
-            ]),
+            RngAlgorithm::XorShift => Seed::XorShift(TestRng::SEED_FOR_XOR_SHIFT),
+            RngAlgorithm::ChaCha => Seed::ChaCha(TestRng::SEED_FOR_CHA_CHA),
             RngAlgorithm::PassThrough => {
                 panic!("deterministic RNG not available for PassThrough")
             }


### PR DESCRIPTION
This allows `no_std` builds to use the `rdrand` instruction on x86
to generate a random seed for the random number generators.

An example invocation to enable it be:
```
cargo +nightly run --example fib --features alloc --features unstable --features hardware-rng --no-default-features
```