### PR TITLE
Replace `into_iter()` with `iter()`

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Deprecations
+
+- `into_iter()` has been deprecated for arrays in 1.41 and replaced with
+  `iter()`. See[Issue #66145](https://github.com/rust-lang/rust/issues/66145) .
+
 ## 0.9.4
 
 ### Bug Fixes

--- a/proptest/src/arbitrary/_std/io.rs
+++ b/proptest/src/arbitrary/_std/io.rs
@@ -116,7 +116,7 @@ arbitrary!(ErrorKind, Union<Just<Self>>;
     , Other
     , UnexpectedEof
     // TODO: watch this type for variant-additions.
-    ].into_iter().cloned().map(Just))
+    ].iter().cloned().map(Just))
 );
 
 arbitrary!(


### PR DESCRIPTION
`into_iter()` has been deprecated for arrays in 1.41 and replaced with
`iter()`. See https://github.com/rust-lang/rust/issues/66145 .

Signed-off-by: Joshua Sorenson <shirt.pants.wallet@gmail.com>