### PR TITLE
Add `#[proptest]` proc-macro with `#[strategy]` argument attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 dist: trusty
 rust:
 - 1.32.0
+- 1.39.0
 - stable
 - beta
 - nightly
@@ -24,6 +25,8 @@ script:
       (cd proptest/test-persistence-location && ./run-tests.sh) &&
       cargo clean &&
       (cd proptest-derive && env TRAVIS_CARGO_NIGHTLY_FEATURE= travis-cargo build) &&
-      (cd proptest-derive && env TRAVIS_CARGO_NIGHTLY_FEATURE= travis-cargo --only nightly test)
+      (cd proptest-derive && env TRAVIS_CARGO_NIGHTLY_FEATURE= travis-cargo --only nightly test) &&
+      (cd proptest-attributes && travis-cargo --only 1.39.0 build) &&
+      (cd proptest-attributes && travis-cargo --only 1.39.0 test)
 
 cache: cargo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,9 @@ You need to use the latest nightly for the following:
 
 - Testing `proptest-derive`.
 
+The `proptest-attributes` crate requires at least Rust 1.39 to support
+attributes in argument positions.
+
 ### Coding
 
 Within the `proptest` crate, you cannot refer to `std` outside of test code or

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "proptest",
+    "proptest-attributes",
     "proptest-derive",
 ]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,18 @@
 environment:
+  TEST_CMD: cargo test -p proptest -p proptest-attributes
+  BUILD_CMD: cargo build -p proptest -p proptest-attributes
   matrix:
   - TARGET: nightly-x86_64-pc-windows-msvc
   - TARGET: nightly-i686-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu
   - TARGET: nightly-i686-pc-windows-gnu
   - TARGET: 1.32.0-x86_64-pc-windows-gnu
+    TEST_CMD: cargo test -p proptest
+    BUILD_CMD: cargo build -p proptest
+    # proptest-attributes has 1.40 MSRV
+  - TARGET: 1.40.0-x86_64-pc-windows-gnu
+    TEST_CMD: cargo test -p proptest-attributes
+    BUILD_CMD: cargo build -p proptest-attributes
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe" -FileName "rust-install.exe"
   - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
@@ -12,7 +20,7 @@ install:
   - rustc -vV
   - cargo -vV
 build_script:
-  - cargo build --all
+  - ps: $env.BUILD_CMD
 test_script:
-  - cargo test -p proptest
+  - ps: $env.TEST_CMD
   - cd proptest\test-persistence-location & run-tests.bat

--- a/proptest-attributes/Cargo.toml
+++ b/proptest-attributes/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "proptest-attributes"
+version = "0.1.0"
+authors = ["David Barsky <me@davidbarsky.com>", "Thomas Eizinger <thomas@eizinger.io>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proptest = { version = "0.10", path = "../proptest" }
+syn = { version = "1", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
+
+[dev-dependencies]
+trybuild = "1.0"
+rustversion = "1.0"

--- a/proptest-attributes/src/lib.rs
+++ b/proptest-attributes/src/lib.rs
@@ -1,0 +1,87 @@
+//-
+// Copyright 2019, 2020 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{spanned::Spanned, FnArg, ItemFn};
+
+#[proc_macro_attribute]
+pub fn proptest(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as ItemFn);
+
+    make_test_fn(input).unwrap_or_else(|e| e).into()
+}
+
+fn make_test_fn(
+    input: ItemFn,
+) -> Result<proc_macro2::TokenStream, proc_macro2::TokenStream> {
+    let name = &input.sig.ident;
+    let inputs = &input.sig.inputs;
+    let body = &input.block;
+
+    let params = inputs
+        .iter()
+        .map(|input| {
+            match input {
+                FnArg::Typed(param) => make_proptest_param(param),
+                FnArg::Receiver(recv) => Err(quote_spanned! { recv.span() =>
+                    compile_error!("The `#[proptest]` macro cannot be applied to a method.");
+                })
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let test_fn = quote! {
+        #[test]
+        fn #name() {
+            proptest::proptest!(|(#(#params),*)| {
+                #body
+            })
+        }
+    };
+
+    Ok(test_fn)
+}
+
+fn make_proptest_param(
+    param: &syn::PatType,
+) -> Result<proc_macro2::TokenStream, proc_macro2::TokenStream> {
+    let param_name = &param.pat;
+    let param_type = &param.ty;
+
+    let strategy = match param.attrs.first() {
+        Some(attr) => {
+            if !attr.path.is_ident("strategy") {
+                return Err(quote_spanned! { attr.span() =>
+                    fn test(#attr #param_name: #param_type) {}
+                });
+            }
+
+            let strategy = match attr.parse_args::<syn::Expr>() {
+                Ok(strategy) => strategy,
+                Err(e) => return Err(e.to_compile_error()),
+            };
+
+            if param.attrs.len() > 1 {
+                return Err(quote_spanned! { param.attrs[1].span() =>
+                    compile_error!("Expected at maximum one #[strategy] attribute");
+                });
+            }
+
+            quote! { #strategy }
+        }
+        None => {
+            quote! { ::proptest::arbitrary::any::<#param_type>() }
+        }
+    };
+
+    Ok(quote! { #param_name in #strategy })
+}

--- a/proptest-attributes/tests/compile-fail/empty_strategy.rs
+++ b/proptest-attributes/tests/compile-fail/empty_strategy.rs
@@ -1,0 +1,15 @@
+//-
+// Copyright 2019, 2020 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use proptest_attributes::proptest;
+
+#[proptest]
+fn function_arn(#[strategy] arg: String) {}
+
+fn main() {}

--- a/proptest-attributes/tests/compile-fail/empty_strategy.stderr
+++ b/proptest-attributes/tests/compile-fail/empty_strategy.stderr
@@ -1,0 +1,5 @@
+error: expected attribute arguments in parentheses: #[strategy(...)]
+ --> $DIR/empty_strategy.rs:4:17
+  |
+4 | fn function_arn(#[strategy] arg: String) {}
+  |                 ^^^^^^^^^^^

--- a/proptest-attributes/tests/compile-fail/method.rs
+++ b/proptest-attributes/tests/compile-fail/method.rs
@@ -1,0 +1,20 @@
+//-
+// Copyright 2019, 2020 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+
+use proptest_attributes::proptest;
+
+struct SomeStruct;
+
+impl SomeStruct {
+    #[proptest]
+    fn function_arn(&self) {}
+}
+
+fn main() {}

--- a/proptest-attributes/tests/compile-fail/method.stderr
+++ b/proptest-attributes/tests/compile-fail/method.stderr
@@ -1,0 +1,5 @@
+error: The `#[proptest]` macro cannot be applied to a method.
+ --> $DIR/method.rs:7:21
+  |
+7 |     fn function_arn(&self) {}
+  |                     ^

--- a/proptest-attributes/tests/compile-fail/two_strategies.rs
+++ b/proptest-attributes/tests/compile-fail/two_strategies.rs
@@ -1,0 +1,20 @@
+//-
+// Copyright 2019, 2020 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use proptest_attributes::proptest;
+
+#[proptest]
+fn function_arn(
+    #[strategy("[A-Z]{1}")]
+    #[strategy("[a-z]{1}")]
+    arg: String,
+) {
+}
+
+fn main() {}

--- a/proptest-attributes/tests/compile-fail/two_strategies.stderr
+++ b/proptest-attributes/tests/compile-fail/two_strategies.stderr
@@ -1,0 +1,5 @@
+error: Expected at maximum one #[strategy] attribute
+ --> $DIR/two_strategies.rs:6:5
+  |
+6 |     #[strategy("[a-z]{1}")]
+  |     ^

--- a/proptest-attributes/tests/compile-fail/wrong_attribute.rs
+++ b/proptest-attributes/tests/compile-fail/wrong_attribute.rs
@@ -1,0 +1,15 @@
+//-
+// Copyright 2019, 2020 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use proptest_attributes::proptest;
+
+#[proptest]
+fn function_arn(#[foobar] arg: String) {}
+
+fn main() {}

--- a/proptest-attributes/tests/compile-fail/wrong_attribute.stderr
+++ b/proptest-attributes/tests/compile-fail/wrong_attribute.stderr
@@ -1,0 +1,5 @@
+error: cannot find attribute `foobar` in this scope
+ --> $DIR/wrong_attribute.rs:4:19
+  |
+4 | fn function_arn(#[foobar] arg: String) {}
+  |                   ^^^^^^

--- a/proptest-attributes/tests/hello.rs
+++ b/proptest-attributes/tests/hello.rs
@@ -1,0 +1,105 @@
+//-
+// Copyright 2019, 2020 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use proptest::{
+    prelude::*, prop_assert_eq, strategy::Strategy, string::string_regex,
+};
+use proptest_attributes::proptest;
+
+fn parse_date(s: &str) -> Option<(u32, u32, u32)> {
+    if 10 != s.len() {
+        return None;
+    }
+
+    // NEW: Ignore non-ASCII strings so we don't need to deal with Unicode.
+    if !s.is_ascii() {
+        return None;
+    }
+
+    if "-" != &s[4..5] || "-" != &s[7..8] {
+        return None;
+    }
+
+    let year = &s[0..4];
+    let month = &s[5..7];
+    let day = &s[8..10];
+
+    year.parse::<u32>().ok().and_then(|y| {
+        month
+            .parse::<u32>()
+            .ok()
+            .and_then(|m| day.parse::<u32>().ok().map(|d| (y, m, d)))
+    })
+}
+
+fn gen_valid_date() -> impl Strategy<Value = String> {
+    let expr = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
+    string_regex(expr).unwrap()
+}
+
+fn gen_all_utf8() -> impl Strategy<Value = String> {
+    let expr = "\\PC*";
+    string_regex(expr).unwrap()
+}
+
+prop_compose! {
+  fn gen_parsed_date()(year in 0u32..10000, month in 1u32..13, day in 1u32..32) -> (u32, u32, u32) {
+    (year, month, day)
+  }
+}
+
+#[proptest]
+fn parses_all_valid_dates(#[strategy(gen_valid_date())] s: String) {
+    parse_date(&s).unwrap();
+}
+
+#[proptest]
+fn doesnt_crash(#[strategy(gen_all_utf8())] s: String) {
+    parse_date(&s);
+}
+
+#[proptest]
+fn parses_date_back_to_original(
+    #[strategy(gen_parsed_date())] date_tuple: (u32, u32, u32),
+) {
+    let (y, m, d) = date_tuple;
+    let (y2, m2, d2) =
+        parse_date(&format!("{:04}-{:02}-{:02}", y, m, d)).unwrap();
+    // prop_assert_eq! is basically the same as assert_eq!, but doesn't
+    // cause a bunch of panic messages to be printed on intermediate
+    // test failures. Which one to use is largely a matter of taste.
+    prop_assert_eq!((y, m, d), (y2, m2, d2));
+}
+
+fn checked_add(left: u64, right: u64) -> Option<u64> {
+    left.checked_add(right)
+}
+
+#[proptest]
+fn default_strategy(first: u64, second: u64) {
+    let sum = checked_add(first, second);
+
+    assert_eq!(sum, first.checked_add(second));
+}
+
+#[proptest]
+fn multiple_strategies(
+    #[strategy("[A-z]{10}")] first: String,
+    #[strategy("[A-z]{5}")] second: String,
+) {
+    assert_eq!(first.len(), 10);
+    assert_eq!(second.len(), 5);
+}
+
+#[proptest]
+fn built_in_strategies(
+    #[strategy(prop::collection::vec(1..10, 5))] numbers: Vec<u32>,
+) {
+    assert_eq!(numbers.len(), 5);
+}

--- a/proptest-attributes/tests/lib.rs
+++ b/proptest-attributes/tests/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[rustversion::attr(nightly, ignore)]
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+    t.pass("tests/ui/*.rs");
+}

--- a/proptest-attributes/tests/ui/basic.rs
+++ b/proptest-attributes/tests/ui/basic.rs
@@ -1,0 +1,29 @@
+//-
+// Copyright 2019, 2020 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use proptest::{strategy::Strategy, string::string_regex};
+use proptest_attributes::proptest;
+
+#[derive(Debug, Clone, PartialEq)]
+struct FunctionArn(String);
+
+fn gen_function_arn() -> impl Strategy<Value = FunctionArn> {
+    let expr = "arn:aws:lambda:us-east-1:[0-9]{12}:function:custom-runtime";
+    let arn = string_regex(expr).unwrap();
+    arn.prop_map(FunctionArn)
+}
+
+#[proptest]
+fn function_arn(#[strategy(gen_function_arn())] arn: FunctionArn) {
+    let mut map = std::collections::HashMap::new();
+    map.insert("arn", arn.clone());
+    proptest::prop_assert_eq!(map.get("arn"), Some(&arn));
+}
+
+fn main() {}

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### New Features
+
+- Introduce the `proptest-attributes` crate. It exposes a proc-macro
+`#[proptest]` for declaring proptests. The proptest-attributes crate
+has a MSRV of 1.39.
+
 ## 0.10.1
 
 ### New Features


### PR DESCRIPTION
This is based on the work from @davidbarsky in https://github.com/AltSysrq/proptest/pull/166 but expands on it to allow for multiple strategies by making use of argument attributes.

