### PR TITLE
Fix compiler warning

### DIFF
--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -170,7 +170,7 @@ fn default_default_config() -> Config {
 #[cfg(feature = "std")]
 lazy_static! {
     static ref DEFAULT_CONFIG: Config =
-        { contextualize_config(default_default_config()) };
+        contextualize_config(default_default_config());
 }
 
 /// Configuration for how a proptest test should be run.


### PR DESCRIPTION
The recent nightly compiler is generating a warning about these parenthesis.
Those warnings cause build-failures when trying to use `trybuild` to do UI tests for the `#[proptest]` macro added in PR https://github.com/AltSysrq/proptest/pull/188.