### PR TITLE
Replace TupleUnion with LazyTupleUnion

### DIFF
--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -25,7 +25,7 @@ use crate::util::self_ty;
 // Config
 //==============================================================================
 
-/// The `MAX - 1` number of strategies that `LazyTupleUnion` supports.
+/// The `MAX - 1` number of strategies that `TupleUnion` supports.
 /// Increase this if the behaviour is changed in `proptest`.
 /// Keeping this lower than what `proptest` supports will also work
 /// but for optimality this should follow what `proptest` supports.
@@ -518,23 +518,23 @@ impl ToTokens for Ctor {
 /// supporting enums with an unbounded number of variants without any boxing
 /// (erasure) or dynamic dispatch.
 ///
-/// As `LazyTupleUnion` is (currently) limited to 10 summands in the coproduct
+/// As `TupleUnion` is (currently) limited to 10 summands in the coproduct
 /// we can't just emit the entire thing linearly as this will fail on the 11:th
 /// variant.
 ///
 /// A naive approach to solve might be to simply use a cons-list like so:
 ///
 /// ```ignore
-/// LazyTupleUnion::new(
+/// TupleUnion::new(
 ///     (w_1, s_1),
 ///     (w_2 + w_3 + w_4 + w_5,
-///      LazyTupleUnion::new(
+///      TupleUnion::new(
 ///         (w_2, s_2),
 ///         (w_3 + w_4 + w_5,
-///          LazyTupleUnion::new(
+///          TupleUnion::new(
 ///             (w_3, s_3),
 ///             (w_4 + w_5,
-///              LazyTupleUnion::new(
+///              TupleUnion::new(
 ///                 (w_4, s_4),
 ///                 (w_5, s_5),
 ///             ))
@@ -568,7 +568,7 @@ fn union_ctor_to_tokens(tokens: &mut TokenStream, ctors: &[(u32, Ctor)]) {
     let tail = Recurse(weight_sum(ctors) - weight_sum(chunk), chunks);
 
     quote_append!(tokens,
-        _proptest::strategy::LazyTupleUnion::new(( #(#head,)* #tail ))
+        _proptest::strategy::TupleUnion::new(( #(#head,)* #tail ))
     );
 
     struct Recurse<'a>(u32, ::std::slice::Chunks<'a, (u32, Ctor)>);
@@ -586,7 +586,7 @@ fn union_ctor_to_tokens(tokens: &mut TokenStream, ctors: &[(u32, Ctor)]) {
                     let tail = Recurse(tweight - weight_sum(chunk), chunks);
                     quote_append!(tokens,
                         (#tweight, ::std::sync::Arc::new(
-                            _proptest::strategy::LazyTupleUnion::new((
+                            _proptest::strategy::TupleUnion::new((
                                 #(#head,)* #tail
                             ))))
                     );
@@ -626,7 +626,7 @@ fn union_strat_to_tokens(tokens: &mut TokenStream, strats: &[Strategy]) {
     let tail = Recurse(chunks);
 
     quote_append!(tokens,
-        _proptest::strategy::LazyTupleUnion<( #(#head,)* #tail )>
+        _proptest::strategy::TupleUnion<( #(#head,)* #tail )>
     );
 
     struct Recurse<'a>(::std::slice::Chunks<'a, Strategy>);
@@ -644,7 +644,7 @@ fn union_strat_to_tokens(tokens: &mut TokenStream, strats: &[Strategy]) {
                     let tail = Recurse(chunks);
                     quote_append!(tokens,
                         (u32,
-                         ::std::sync::Arc<_proptest::strategy::LazyTupleUnion<(
+                         ::std::sync::Arc<_proptest::strategy::TupleUnion<(
                              #(#head,)* #tail
                          )>>)
                     );

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -7,6 +7,10 @@
 - The `proptest!` macro no longer accepts function bodies which implicitly
   return a value (which would then be discarded).
 
+- The `TupleUnion` implementation in `proptest` 0.9 has been removed and
+  replaced with `LazyTupleUnion`. `prop_oneof!` is unaffected and continues
+  to be the recommended way to build a union of strategies.
+
 ### New Features
 
 - Enabling the `hardware-rng` optional depndency (disabled by default) allows

--- a/proptest/src/arbitrary/_alloc/alloc.rs
+++ b/proptest/src/arbitrary/_alloc/alloc.rs
@@ -40,7 +40,7 @@ arbitrary!(self::alloc::AllocErr, Just<Self>; Just(self::alloc::AllocErr));
 /* 2018-07-28 CollectionAllocErr is not currently available outside of using
  * the `alloc` crate, which would require a different nightly feature. For now,
  * disable.
-arbitrary!(alloc::collections::CollectionAllocErr, LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
+arbitrary!(alloc::collections::CollectionAllocErr, TupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
            prop_oneof![Just(alloc::collections::CollectionAllocErr::AllocErr),
                        Just(alloc::collections::CollectionAllocErr::CapacityOverflow)]);
  */

--- a/proptest/src/arbitrary/_alloc/collections.rs
+++ b/proptest/src/arbitrary/_alloc/collections.rs
@@ -247,7 +247,7 @@ impl<A: fmt::Debug + Ord + 'static, B: fmt::Debug + 'static>
 //==============================================================================
 
 arbitrary!([A: Arbitrary] Bound<A>,
-    LazyTupleUnion<(
+    TupleUnion<(
         WA<SFnPtrMap<Arc<A::Strategy>, Self>>,
         WA<SFnPtrMap<Arc<A::Strategy>, Self>>,
         WA<LazyJustFn<Self>>

--- a/proptest/src/arbitrary/_alloc/ops.rs
+++ b/proptest/src/arbitrary/_alloc/ops.rs
@@ -49,7 +49,7 @@ lift1!([PartialOrd] Range<A>; base => {
 #[cfg(feature = "unstable")]
 arbitrary!(
     [Y: Arbitrary, R: Arbitrary] GeneratorState<Y, R>,
-    LazyTupleUnion<(WA<SMapped<Y, Self>>, WA<SMapped<R, Self>>)>,
+    TupleUnion<(WA<SMapped<Y, Self>>, WA<SMapped<R, Self>>)>,
     product_type![Y::Parameters, R::Parameters];
     args => {
         let product_unpack![y, r] = args;

--- a/proptest/src/arbitrary/_alloc/str.rs
+++ b/proptest/src/arbitrary/_alloc/str.rs
@@ -20,7 +20,7 @@ use crate::strategy::*;
 arbitrary!(ParseBoolError; "".parse::<bool>().unwrap_err());
 
 type ELSeq = WA<Just<&'static [u8]>>;
-type ELSeqs = LazyTupleUnion<(ELSeq, ELSeq, ELSeq, ELSeq)>;
+type ELSeqs = TupleUnion<(ELSeq, ELSeq, ELSeq, ELSeq)>;
 
 fn gen_el_seqs() -> ELSeqs {
     prop_oneof![

--- a/proptest/src/arbitrary/_alloc/sync.rs
+++ b/proptest/src/arbitrary/_alloc/sync.rs
@@ -37,8 +37,8 @@ atomic!(AtomicI8, i8; AtomicI16, i16; AtomicI32, i32;
 atomic!(AtomicI64, i64; AtomicU64, u64);
 
 arbitrary!(Ordering,
-    LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
-                    WA<Just<Self>>, WA<Just<Self>>)>;
+    TupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
+                WA<Just<Self>>, WA<Just<Self>>)>;
     prop_oneof![
         Just(Ordering::Relaxed),
         Just(Ordering::Release),

--- a/proptest/src/arbitrary/_core/cmp.rs
+++ b/proptest/src/arbitrary/_core/cmp.rs
@@ -11,12 +11,12 @@
 
 use core::cmp::{Ordering, Reverse};
 
-use crate::strategy::{Just, LazyTupleUnion, WA};
+use crate::strategy::{Just, TupleUnion, WA};
 
 wrap_ctor!(Reverse, Reverse);
 
 type WAJO = WA<Just<Ordering>>;
-arbitrary!(Ordering, LazyTupleUnion<(WAJO, WAJO, WAJO)>;
+arbitrary!(Ordering, TupleUnion<(WAJO, WAJO, WAJO)>;
     prop_oneof![
         Just(Ordering::Equal),
         Just(Ordering::Less),

--- a/proptest/src/arbitrary/_core/num.rs
+++ b/proptest/src/arbitrary/_core/num.rs
@@ -25,8 +25,8 @@ arbitrary!(TryFromIntError; {
 wrap_ctor!(Wrapping, Wrapping);
 
 arbitrary!(FpCategory,
-    LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
-                    WA<Just<Self>>, WA<Just<Self>>)>;
+    TupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
+                WA<Just<Self>>, WA<Just<Self>>)>;
     {
         use core::num::FpCategory::*;
         prop_oneof![

--- a/proptest/src/arbitrary/_std/env.rs
+++ b/proptest/src/arbitrary/_std/env.rs
@@ -98,7 +98,7 @@ mod var_error {
     }
 
     arbitrary!(VarError,
-        LazyTupleUnion<(
+        TupleUnion<(
             WA<Just<Self>>,
             WA<SFnPtrMap<BoxedStrategy<OsString>, Self>>
         )>;

--- a/proptest/src/arbitrary/_std/io.rs
+++ b/proptest/src/arbitrary/_std/io.rs
@@ -121,7 +121,7 @@ arbitrary!(ErrorKind, Union<Just<Self>>;
 
 arbitrary!(
     SeekFrom,
-    LazyTupleUnion<(
+    TupleUnion<(
         WA<SMapped<u64, SeekFrom>>,
         WA<SMapped<i64, SeekFrom>>,
         WA<SMapped<i64, SeekFrom>>,

--- a/proptest/src/arbitrary/_std/net.rs
+++ b/proptest/src/arbitrary/_std/net.rs
@@ -21,7 +21,7 @@ use crate::strategy::*;
 arbitrary!(AddrParseError; "".parse::<Ipv4Addr>().unwrap_err());
 
 arbitrary!(Ipv4Addr,
-    LazyTupleUnion<(
+    TupleUnion<(
         WA<Just<Self>>,
         WA<Just<Self>>,
         WA<MapInto<StrategyFor<u32>, Self>>
@@ -34,7 +34,7 @@ arbitrary!(Ipv4Addr,
 );
 
 arbitrary!(Ipv6Addr,
-    LazyTupleUnion<(
+    TupleUnion<(
         WA<SMapped<Ipv4Addr, Self>>,
         WA<MapInto<StrategyFor<[u16; 8]>, Self>>
     )>;
@@ -54,8 +54,8 @@ arbitrary!(SocketAddrV6, SMapped<(Ipv6Addr, u16, u32, u32), Self>;
 );
 
 arbitrary!(IpAddr,
-    LazyTupleUnion<(WA<MapInto<StrategyFor<Ipv4Addr>, Self>>,
-                    WA<MapInto<StrategyFor<Ipv6Addr>, Self>>)>;
+    TupleUnion<(WA<MapInto<StrategyFor<Ipv4Addr>, Self>>,
+                WA<MapInto<StrategyFor<Ipv6Addr>, Self>>)>;
     prop_oneof![
         any::<Ipv4Addr>().prop_map_into(),
         any::<Ipv6Addr>().prop_map_into()
@@ -63,15 +63,15 @@ arbitrary!(IpAddr,
 );
 
 arbitrary!(Shutdown,
-    LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>)>;
+    TupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>)>;
     {
         use std::net::Shutdown::*;
         prop_oneof![Just(Both), Just(Read), Just(Write)]
     }
 );
 arbitrary!(SocketAddr,
-    LazyTupleUnion<(WA<MapInto<StrategyFor<SocketAddrV4>, Self>>,
-                    WA<MapInto<StrategyFor<SocketAddrV6>, Self>>)>;
+    TupleUnion<(WA<MapInto<StrategyFor<SocketAddrV4>, Self>>,
+                WA<MapInto<StrategyFor<SocketAddrV6>, Self>>)>;
     prop_oneof![
         any::<SocketAddrV4>().prop_map_into(),
         any::<SocketAddrV6>().prop_map_into()
@@ -80,9 +80,9 @@ arbitrary!(SocketAddr,
 
 #[cfg(feature = "unstable")]
 arbitrary!(Ipv6MulticastScope,
-    LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
-                    WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
-                    WA<Just<Self>>)>;
+    TupleUnion<(WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
+                WA<Just<Self>>, WA<Just<Self>>, WA<Just<Self>>,
+                WA<Just<Self>>)>;
     {
         use std::net::Ipv6MulticastScope::*;
         prop_oneof![

--- a/proptest/src/arbitrary/_std/sync.rs
+++ b/proptest/src/arbitrary/_std/sync.rs
@@ -40,7 +40,7 @@ arbitrary!(Barrier, SMapped<u16, Self>;  // usize would be extreme!
 );
 
 arbitrary!(BarrierWaitResult,
-    LazyTupleUnion<(WA<LazyJustFn<Self>>, WA<LazyJustFn<Self>>)>;
+    TupleUnion<(WA<LazyJustFn<Self>>, WA<LazyJustFn<Self>>)>;
     prop_oneof![LazyJust::new(bwr_true), LazyJust::new(bwr_false)]
 );
 
@@ -49,7 +49,7 @@ lazy_just!(
     Once, Once::new
 );
 
-arbitrary!(WaitTimeoutResult, LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
+arbitrary!(WaitTimeoutResult, TupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
     prop_oneof![Just(wtr_true()), Just(wtr_false())]
 );
 
@@ -96,14 +96,14 @@ arbitrary!([T: Arbitrary] SendError<T>, SMapped<T, Self>, T::Parameters;
     args => static_map(any_with::<T>(args), SendError)
 );
 
-arbitrary!(RecvTimeoutError, LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
+arbitrary!(RecvTimeoutError, TupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
     prop_oneof![
         Just(RecvTimeoutError::Disconnected),
         Just(RecvTimeoutError::Timeout)
     ]
 );
 
-arbitrary!(TryRecvError, LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
+arbitrary!(TryRecvError, TupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
     prop_oneof![
         Just(TryRecvError::Disconnected),
         Just(TryRecvError::Empty)
@@ -112,7 +112,7 @@ arbitrary!(TryRecvError, LazyTupleUnion<(WA<Just<Self>>, WA<Just<Self>>)>;
 
 arbitrary!(
     [P: Clone + Default, T: Arbitrary<Parameters = P>] TrySendError<T>,
-    LazyTupleUnion<(WA<SMapped<T, Self>>, WA<SMapped<T, Self>>)>, P;
+    TupleUnion<(WA<SMapped<T, Self>>, WA<SMapped<T, Self>>)>, P;
     args => prop_oneof![
         static_map(any_with::<T>(args.clone()), TrySendError::Disconnected),
         static_map(any_with::<T>(args), TrySendError::Full),

--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -335,7 +335,7 @@ macro_rules! prop_oneof {
 
     ($weight0:expr => $item0:expr,
      $weight1:expr => $item1:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1))))
     };
@@ -343,7 +343,7 @@ macro_rules! prop_oneof {
     ($weight0:expr => $item0:expr,
      $weight1:expr => $item1:expr,
      $weight2:expr => $item2:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2))))
@@ -353,7 +353,7 @@ macro_rules! prop_oneof {
      $weight1:expr => $item1:expr,
      $weight2:expr => $item2:expr,
      $weight3:expr => $item3:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2)),
@@ -365,7 +365,7 @@ macro_rules! prop_oneof {
      $weight2:expr => $item2:expr,
      $weight3:expr => $item3:expr,
      $weight4:expr => $item4:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2)),
@@ -379,7 +379,7 @@ macro_rules! prop_oneof {
      $weight3:expr => $item3:expr,
      $weight4:expr => $item4:expr,
      $weight5:expr => $item5:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2)),
@@ -395,7 +395,7 @@ macro_rules! prop_oneof {
      $weight4:expr => $item4:expr,
      $weight5:expr => $item5:expr,
      $weight6:expr => $item6:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2)),
@@ -413,7 +413,7 @@ macro_rules! prop_oneof {
      $weight5:expr => $item5:expr,
      $weight6:expr => $item6:expr,
      $weight7:expr => $item7:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2)),
@@ -433,7 +433,7 @@ macro_rules! prop_oneof {
      $weight6:expr => $item6:expr,
      $weight7:expr => $item7:expr,
      $weight8:expr => $item8:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2)),
@@ -455,7 +455,7 @@ macro_rules! prop_oneof {
      $weight7:expr => $item7:expr,
      $weight8:expr => $item8:expr,
      $weight9:expr => $item9:expr $(,)?) => {
-        $crate::strategy::LazyTupleUnion::new(
+        $crate::strategy::TupleUnion::new(
             (($weight0, $crate::std_facade::Arc::new($item0)),
              ($weight1, $crate::std_facade::Arc::new($item1)),
              ($weight2, $crate::std_facade::Arc::new($item2)),
@@ -1328,7 +1328,7 @@ mod test {
 
     #[test]
     fn oneof_all_counts() {
-        use crate::strategy::{Just as J, LazyTupleUnion, Strategy, Union};
+        use crate::strategy::{Just as J, Strategy, TupleUnion, Union};
 
         fn expect_count(n: usize, s: impl Strategy<Value = i32>) {
             use crate::strategy::*;
@@ -1344,7 +1344,7 @@ mod test {
             assert_eq!(n, seen.len());
         }
 
-        fn assert_static<T>(v: LazyTupleUnion<T>) -> LazyTupleUnion<T> {
+        fn assert_static<T>(v: TupleUnion<T>) -> TupleUnion<T> {
             v
         }
         fn assert_dynamic<T: Strategy>(v: Union<T>) -> Union<T> {


### PR DESCRIPTION
LazyTupleUnion was added in #144 to improve performance of union
strategies. This commit removes the old TupleUnion impl and
replaces it with LazyTupleUnion.