### PR TITLE
Update to version 2 of quick-error

### DIFF
--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -79,7 +79,7 @@ version = "0.2.2"
 default-features = false
 
 [dependencies.quick-error]
-version = "1.2.1"
+version = "2.0.0"
 optional = true
 
 [dependencies.regex-syntax]

--- a/proptest/src/string.rs
+++ b/proptest/src/string.rs
@@ -55,9 +55,8 @@ impl Default for StringParam {
 }
 
 // quick_error! uses bare trait objects, so we enclose its invocation here in a
-// module so the lint can be disabled just for it. Also suppress deprecation
-// due to .description().
-#[allow(bare_trait_objects, deprecated)]
+// module so the lint can be disabled just for it.
+#[allow(bare_trait_objects)]
 mod error_container {
     use super::*;
 
@@ -69,14 +68,13 @@ mod error_container {
             /// The string passed as the regex was not syntactically valid.
             RegexSyntax(err: ParseError) {
                 from()
-                    cause(err)
-                    description(err.description())
+                    source(err)
                     display("{}", err)
             }
             /// The regex was syntactically valid, but contains elements not
             /// supported by proptest.
             UnsupportedRegex(message: &'static str) {
-                description(message)
+                display("{}", message)
             }
         }
     }


### PR DESCRIPTION
This just updates `quick-error` to version 2. This did involve switching `cause` over to `source` and removing `description` since both were deprecated since rust 1.33.0 and 1.42.0 respectively. (Deja vu)

I noticed there are unrelated problems trying to test `proptest-derive` which will probably cause CI to fail.