### PR TITLE
Fixed version number in docs

### DIFF
--- a/book/src/proptest-derive/getting-started.md
+++ b/book/src/proptest-derive/getting-started.md
@@ -5,7 +5,7 @@
 To the `[dev-dependencies]` section of your `Cargo.toml`, add
 
 ```toml
-proptest-derive = "0.1.0"
+proptest-derive = "0.2.0"
 ```
 
 In a Rust 2015 crate, you must add


### PR DESCRIPTION
Updated example code in the Book to use the correct version numbers to avoid trivial errors in copy & paste.

Fixes #208 