### PR TITLE
Support larger tuples (up to 12 elements)

### DIFF
--- a/proptest/src/tuple.rs
+++ b/proptest/src/tuple.rs
@@ -99,6 +99,8 @@ tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G);
 tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H);
 tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I);
 tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J);
+tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K);
+tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L);
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
The standard library implements `Debug` for tuples up to 12 elements, so we should be able to support them here. Occasionally we wound encounter such types in our tests.