### PR TITLE
Fix typo in `unknown_modifier` error definition

### DIFF
--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -439,10 +439,10 @@ error!(
     expected
 );
 
-// TODO: `unkown_modifier` is misspelled
+// TODO: `unknown_modifier` is misspelled
 // Happens when `<modifier>` in `#[proptest(<modifier>)]` is unknown to us.
 error!(
-    unkown_modifier(modifier: &str),
+    unknown_modifier(modifier: &str),
     E0018,
     "Unknown attribute modifier `{}` inside `#[proptest(..)]` is not allowed.",
     modifier


### PR DESCRIPTION


### Description

This pull request corrects a typo in the `unknown_modifier` error variant within the `proptest-derive` crate.

The change includes:
*   Renaming the `unknwn_modifier` variant to `unknown_modifier`.
