### PR TITLE
Correctly set `Config::test_name` in `#[proptest::property_test]`

### DIFF
--- a/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__arg_ident_and_pattern.snap
+++ b/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__arg_ident_and_pattern.snap
@@ -39,7 +39,7 @@ fn foo() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(foo))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };

--- a/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__arg_pattern.snap
+++ b/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__arg_pattern.snap
@@ -20,7 +20,7 @@ fn foo() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(foo))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };

--- a/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__many_params.snap
+++ b/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__many_params.snap
@@ -21,7 +21,7 @@ fn foo() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(foo))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };

--- a/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__return_value.snap
+++ b/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__return_value.snap
@@ -21,7 +21,7 @@ fn return_value() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(return_value))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };

--- a/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__simple.snap
+++ b/proptest-macro/src/property_test/codegen/snapshots/proptest_macro__property_test__codegen__snapshot_tests__simple.snap
@@ -20,7 +20,7 @@ fn foo() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(foo))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };

--- a/proptest-macro/src/property_test/codegen/test_body.rs
+++ b/proptest-macro/src/property_test/codegen/test_body.rs
@@ -49,7 +49,7 @@ pub(super) fn body(
 
     let handle_result = handle_result(ret_ty);
 
-    let config = make_config(options.config.as_ref());
+    let config = make_config(options.config.as_ref(), fn_name);
 
     let tokens = quote! ( {
 
@@ -103,7 +103,7 @@ fn handle_result(ret_ty: &ReturnType) -> TokenStream {
     }
 }
 
-fn make_config(config: Option<&Expr>) -> TokenStream {
+fn make_config(config: Option<&Expr>, fn_name: &Ident) -> TokenStream {
     let trailing = match config {
         None => quote! { ::proptest::test_runner::Config::default() },
         Some(config) => config.to_token_stream(),
@@ -111,7 +111,7 @@ fn make_config(config: Option<&Expr>) -> TokenStream {
 
     quote! {
         let config = ::proptest::test_runner::Config {
-            test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+            test_name: Some(concat!(module_path!(), "::", stringify!(#fn_name))),
             source_file: Some(file!()),
             ..#trailing
         };

--- a/proptest-macro/src/property_test/tests/snapshots/proptest_macro__property_test__tests__snapshot_tests__basic_derive_example.snap
+++ b/proptest-macro/src/property_test/tests/snapshots/proptest_macro__property_test__tests__snapshot_tests__basic_derive_example.snap
@@ -21,7 +21,7 @@ fn foo() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(foo))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };

--- a/proptest-macro/src/property_test/tests/snapshots/proptest_macro__property_test__tests__snapshot_tests__custom_strategy.snap
+++ b/proptest-macro/src/property_test/tests/snapshots/proptest_macro__property_test__tests__snapshot_tests__custom_strategy.snap
@@ -20,7 +20,7 @@ fn foo() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(foo))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };

--- a/proptest-macro/src/property_test/tests/snapshots/proptest_macro__property_test__tests__snapshot_tests__mix_custom_and_default_strategies.snap
+++ b/proptest-macro/src/property_test/tests/snapshots/proptest_macro__property_test__tests__snapshot_tests__mix_custom_and_default_strategies.snap
@@ -20,7 +20,7 @@ fn foo() {
         }
     }
     let config = ::proptest::test_runner::Config {
-        test_name: Some(concat!(module_path!(), "::", stringify!($test_name))),
+        test_name: Some(concat!(module_path!(), "::", stringify!(foo))),
         source_file: Some(file!()),
         ..::proptest::test_runner::Config::default()
     };


### PR DESCRIPTION
`stringify!($test_name)` would expand to `"$test_name"` (not the actual function name) in this context.

Fixes the forking feature being broken (failing with `Child process crashed or timed out before the first test started running [..]`) for tests based on `#[proptest::property_test]`.