### PR TITLE
rand 0.10: port TestRng and rand reexports without changing RNG behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ prettyplease = "0.2"
 proc-macro2 = "1.0"
 proptest-macro = { version = "0.5.0", path = "proptest-macro" }
 quote = "1.0"
-rand = { version = "0.9", default-features = false }
-rand_chacha = { version = "0.9", default-features = false }
-rand_xorshift = "0.4"
+rand = { version = "0.10", default-features = false }
+rand_chacha = { version = "0.10", default-features = false }
+rand_xorshift = "0.5"
 regex = "1.0"
 regex-syntax = "0.8"
 rusty-fork = { version = "0.3.0", default-features = false }

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Other Notes
+
+- Updated the rand dependency family to 0.10 and migrated `TestRng` and internal RNG integration to rand 0.10's trait and seeding APIs, preserving seeded behavior.
+
 ## 1.11.0
 
 ### New Features

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The minimum supported Rust version has been increased to 1.86.0.
 
+### Other Notes
+
+- Updated the rand dependency family to 0.10 and migrated `TestRng` and internal RNG integration to rand 0.10's trait and seeding APIs, preserving seeded behavior.
+
 ## 1.11.0
 
 ### New Features

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -32,7 +32,7 @@ unstable = ["f16"]
 f16 = []
 
 # Enables the use of standard-library dependent features
-std = ["rand/std", "rand/os_rng", "regex-syntax", "num-traits/std"]
+std = ["rand/std", "rand/sys_rng", "regex-syntax", "num-traits/std"]
 
 # std or libm required for mul_add.
 no_std = ["num-traits/libm"]

--- a/proptest/src/bits.rs
+++ b/proptest/src/bits.rs
@@ -24,7 +24,7 @@ use core::mem;
 use bit_set::BitSet;
 #[cfg(feature = "bit-set")]
 use bit_vec::BitVec;
-use rand::{self, seq::IteratorRandom, Rng};
+use rand::{seq::IteratorRandom, RngExt};
 
 use crate::collection::SizeRange;
 use crate::num::sample_uniform_incl;
@@ -286,7 +286,7 @@ impl<T: BitSetLike> Strategy for SampledBitSetStrategy<T> {
             panic!("not enough bits to sample");
         }
 
-        for bit in self.bits.iter().choose_multiple(runner.rng(), count) {
+        for bit in self.bits.iter().sample(runner.rng(), count) {
             bits.set(bit);
         }
 

--- a/proptest/src/bool.rs
+++ b/proptest/src/bool.rs
@@ -12,7 +12,7 @@
 use crate::strategy::*;
 use crate::test_runner::*;
 
-use rand::Rng;
+use rand::RngExt;
 
 /// The type of the `ANY` constant.
 #[derive(Clone, Copy, Debug)]

--- a/proptest/src/char.rs
+++ b/proptest/src/char.rs
@@ -20,7 +20,7 @@
 use crate::std_facade::Cow;
 use core::ops::RangeInclusive;
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use crate::num;
 use crate::strategy::*;

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018 Jason Lingle
+// Copyright 2017, 2018, 2026 Jason Lingle
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -239,7 +239,7 @@ macro_rules! signed_integer_bin_search {
         #[allow(missing_docs)]
         pub mod $typ {
             #[allow(unused_imports)]
-            use rand::{Rng, RngCore};
+            use rand::{Rng, RngExt};
 
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
@@ -345,7 +345,7 @@ macro_rules! unsigned_integer_bin_search {
         #[allow(missing_docs)]
         pub mod $typ {
             #[allow(unused_imports)]
-            use rand::{Rng, RngCore};
+            use rand::{Rng, RngExt};
 
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
@@ -784,7 +784,7 @@ macro_rules! float_bin_search {
             #[cfg(not(feature = "std"))]
             use num_traits::float::FloatCore;
 
-            use rand::Rng;
+            use rand::RngExt;
 
             use super::{FloatLayout, FloatTypes};
             use crate::strategy::*;

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018 Jason Lingle
+// Copyright 2017, 2018, 2026 Jason Lingle
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -250,7 +250,7 @@ macro_rules! signed_integer_bin_search {
         #[allow(missing_docs)]
         pub mod $typ {
             #[allow(unused_imports)]
-            use rand::{Rng, RngCore};
+            use rand::{Rng, RngExt};
 
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
@@ -361,7 +361,7 @@ macro_rules! unsigned_integer_bin_search {
         #[allow(missing_docs)]
         pub mod $typ {
             #[allow(unused_imports)]
-            use rand::{Rng, RngCore};
+            use rand::{Rng, RngExt};
 
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
@@ -811,7 +811,7 @@ macro_rules! float_bin_search {
             #[cfg(not(feature = "std"))]
             use num_traits::float::FloatCore;
 
-            use rand::Rng;
+            use rand::RngExt;
 
             use super::{FloatLayout, FloatTypes};
             use crate::strategy::*;

--- a/proptest/src/prelude.rs
+++ b/proptest/src/prelude.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018, 2019 The proptest developers
+// Copyright 2017, 2018, 2019, 2026 The proptest developers
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -16,9 +16,8 @@
 //! In addition to Proptest's own APIs, this also reexports a small portion of
 //! the `rand` crate sufficient to easily use `prop_perturb` and other
 //! functionality that exposes random number generators. Please note that this
-//! is will always be a direct reexport; using these in preference to using the
-//! `rand` crate directly will not provide insulation from the upcoming
-//! revision to the `rand` crate.
+//! is and will always be a direct reexport; using these in preference to using the
+//! `rand` crate directly will not provide insulation from rand API changes.
 
 pub use crate::arbitrary::{any, any_with, Arbitrary};
 pub use crate::strategy::{BoxedStrategy, Just, SBoxedStrategy, Strategy};
@@ -29,7 +28,9 @@ pub use crate::{
     prop_oneof, proptest,
 };
 
-pub use rand::{Rng, RngCore};
+pub use rand::{Rng, RngExt};
+#[allow(deprecated)]
+pub use rand::rand_core::RngCore;
 
 /// Re-exports the entire public API of proptest so that an import of `prelude`
 /// allows simply writing, for example, `prop::num::i32::ANY` rather than

--- a/proptest/src/range_subset.rs
+++ b/proptest/src/range_subset.rs
@@ -13,7 +13,7 @@
 //! is, the input range is not itself a strategy, but is rather fixed when
 //! the strategy is created.
 
-use rand::Rng;
+use rand::RngExt;
 
 use core::fmt;
 use core::hash::Hash;

--- a/proptest/src/sample.rs
+++ b/proptest/src/sample.rs
@@ -19,7 +19,7 @@ use core::mem;
 use core::ops::Range;
 use core::u64;
 
-use rand::Rng;
+use rand::RngExt;
 
 use crate::bits::{self, BitSetValueTree, SampledBitSetStrategy, VarBitSet};
 use crate::num;

--- a/proptest/src/strategy/map.rs
+++ b/proptest/src/strategy/map.rs
@@ -250,7 +250,7 @@ impl<S: ValueTree, O: fmt::Debug, F: Fn(S::Value, TestRng) -> O> ValueTree
 mod test {
     use std::collections::HashSet;
 
-    use rand::RngCore;
+    use rand::Rng;
 
     use super::*;
     use crate::strategy::just::Just;

--- a/proptest/src/strategy/shuffle.rs
+++ b/proptest/src/strategy/shuffle.rs
@@ -9,7 +9,7 @@
 
 use crate::std_facade::{Cell, Vec, VecDeque};
 
-use rand::Rng;
+use rand::RngExt;
 
 use crate::num;
 use crate::strategy::traits::*;

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -713,4 +713,163 @@ mod test {
         assert_eq!([0, 0, 0, 0], buf);
     }
 
+    #[test]
+    fn seeded_xorshift_output_is_stable() {
+        let seed = [
+            0x00, 0x01, 0x02, 0x03,
+            0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b,
+            0x0c, 0x0d, 0x0e, 0x0f,
+        ];
+        let mut rng_u32 = TestRng::from_seed(RngAlgorithm::XorShift, &seed);
+        let mut rng_u64 = TestRng::from_seed(RngAlgorithm::XorShift, &seed);
+        let mut rng_fill = TestRng::from_seed(RngAlgorithm::XorShift, &seed);
+
+        assert_eq!(
+            [
+                471271404,
+                722341711,
+                1880555887,
+                252576780,
+            ],
+            [
+                rng_u32.next_u32(),
+                rng_u32.next_u32(),
+                rng_u32.next_u32(),
+                rng_u32.next_u32(),
+            ]
+        );
+        assert_eq!(
+            [
+                3102434025752954860,
+                1084809011709542767,
+                17342619095589341798,
+                5127465042768897837,
+            ],
+            [
+                rng_u64.next_u64(),
+                rng_u64.next_u64(),
+                rng_u64.next_u64(),
+                rng_u64.next_u64(),
+            ]
+        );
+
+        let mut fill = [0u8; 16];
+        rng_fill.fill_bytes(&mut fill);
+        assert_eq!(
+            [236, 7, 23, 28, 79, 15, 14, 43, 111, 1, 23, 112, 12, 4, 14, 15],
+            fill
+        );
+    }
+
+    #[test]
+    fn seeded_chacha_output_is_stable() {
+        let seed = [
+            0x00, 0x01, 0x02, 0x03,
+            0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b,
+            0x0c, 0x0d, 0x0e, 0x0f,
+            0x10, 0x11, 0x12, 0x13,
+            0x14, 0x15, 0x16, 0x17,
+            0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ];
+        let mut rng_u32 = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
+        let mut rng_u64 = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
+        let mut rng_fill = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
+
+        assert_eq!(
+            [
+                2100034873,
+                1780073945,
+                1996733837,
+                1229642936,
+            ],
+            [
+                rng_u32.next_u32(),
+                rng_u32.next_u32(),
+                rng_u32.next_u32(),
+                rng_u32.next_u32(),
+            ]
+        );
+        assert_eq!(
+            [
+                7645359380336737593,
+                5281276197874154893,
+                14729830432180286858,
+                10530800043416210610,
+            ],
+            [
+                rng_u64.next_u64(),
+                rng_u64.next_u64(),
+                rng_u64.next_u64(),
+                rng_u64.next_u64(),
+            ]
+        );
+
+        let mut fill = [0u8; 16];
+        rng_fill.fill_bytes(&mut fill);
+        assert_eq!(
+            [57, 253, 43, 125, 217, 197, 25, 106, 141, 189, 3, 119, 184, 220, 74, 73],
+            fill
+        );
+    }
+
+    #[test]
+    fn derived_child_rng_output_is_stable() {
+        let seed = [
+            0x00, 0x01, 0x02, 0x03,
+            0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b,
+            0x0c, 0x0d, 0x0e, 0x0f,
+            0x10, 0x11, 0x12, 0x13,
+            0x14, 0x15, 0x16, 0x17,
+            0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ];
+        let mut parent = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
+        let mut child = parent.gen_rng();
+
+        assert_eq!(
+            [
+                357635273,
+                1295757006,
+                1334659017,
+                3423482104,
+            ],
+            [
+                child.next_u32(),
+                child.next_u32(),
+                child.next_u32(),
+                child.next_u32(),
+            ],
+        );
+    }
+
+    #[test]
+    fn recorder_bytes_used_matches_emitted_bytes() {
+        let seed = [
+            0x00, 0x01, 0x02, 0x03,
+            0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b,
+            0x0c, 0x0d, 0x0e, 0x0f,
+            0x10, 0x11, 0x12, 0x13,
+            0x14, 0x15, 0x16, 0x17,
+            0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ];
+        let mut rng = TestRng::from_seed(RngAlgorithm::Recorder, &seed);
+        let first = rng.next_u32();
+        let second = rng.next_u64();
+        let mut fill = [0u8; 16];
+        rng.fill_bytes(&mut fill);
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&first.to_le_bytes());
+        expected.extend_from_slice(&second.to_le_bytes());
+        expected.extend_from_slice(&fill);
+
+        assert_eq!(expected, rng.bytes_used());
+    }
+
 }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018, 2019, 2020 The proptest developers
+// Copyright 2017, 2018, 2019, 2020, 2026 The proptest developers
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -8,10 +8,13 @@
 // except according to those terms.
 
 use crate::std_facade::{Arc, String, ToOwned, Vec};
+use core::convert::{Infallible, TryInto};
 use core::result::Result;
-use core::{fmt, str, u8, convert::TryInto};
-use crate::test_runner::{config, RngSeed};
-use rand::{self, Rng, RngCore, SeedableRng};
+use core::{fmt, str, u8};
+use crate::test_runner::config;
+use rand::{Rng, RngExt, SeedableRng, TryRng};
+#[cfg(feature = "std")]
+use rand::rngs::SysRng;
 use rand_chacha::ChaChaRng;
 use rand_xorshift::XorShiftRng;
 
@@ -126,14 +129,14 @@ enum TestRngImpl {
     },
 }
 
-impl RngCore for TestRng {
-    fn next_u32(&mut self) -> u32 {
+impl TestRng {
+    fn next_u32_inner(&mut self) -> u32 {
         match &mut self.rng {
             TestRngImpl::XorShift(rng) => rng.next_u32(),
             TestRngImpl::ChaCha(rng) => rng.next_u32(),
             TestRngImpl::PassThrough { .. } => {
                 let mut buf = [0; 4];
-                self.fill_bytes(&mut buf[..]);
+                self.fill_bytes_inner(&mut buf[..]);
                 u32::from_le_bytes(buf)
             }
             TestRngImpl::Recorder { rng, record } => {
@@ -144,13 +147,13 @@ impl RngCore for TestRng {
         }
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn next_u64_inner(&mut self) -> u64 {
         match &mut self.rng {
             TestRngImpl::XorShift(rng) => rng.next_u64(),
             TestRngImpl::ChaCha(rng) => rng.next_u64(),
             TestRngImpl::PassThrough { .. } => {
                 let mut buf = [0; 8];
-                self.fill_bytes(&mut buf[..]);
+                self.fill_bytes_inner(&mut buf[..]);
                 u64::from_le_bytes(buf)
             }
             TestRngImpl::Recorder { rng, record } => {
@@ -161,7 +164,7 @@ impl RngCore for TestRng {
         }
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn fill_bytes_inner(&mut self, dest: &mut [u8]) {
         match &mut self.rng {
             TestRngImpl::XorShift(rng) => rng.fill_bytes(dest),
             TestRngImpl::ChaCha(rng) => rng.fill_bytes(dest),
@@ -178,6 +181,23 @@ impl RngCore for TestRng {
                 record.extend_from_slice(dest);
             }
         }
+    }
+}
+
+impl TryRng for TestRng {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.next_u32_inner())
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.next_u64_inner())
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        self.fill_bytes_inner(dest);
+        Ok(())
     }
 }
 
@@ -387,15 +407,17 @@ impl TestRng {
                 rng: match algorithm {
                     RngAlgorithm::XorShift => {
                         let rng = match seed {
-                            RngSeed::Random => XorShiftRng::from_os_rng(),
-                            RngSeed::Fixed(seed) => XorShiftRng::seed_from_u64(seed),
+                            config::RngSeed::Random => XorShiftRng::try_from_rng(&mut SysRng)
+                                .expect("SysRng failed while seeding TestRng"),
+                            config::RngSeed::Fixed(seed) => XorShiftRng::seed_from_u64(seed),
                         };
                         TestRngImpl::XorShift(rng)
                     }
                     RngAlgorithm::ChaCha => {
                         let rng = match seed {
-                            RngSeed::Random => ChaChaRng::from_os_rng(),
-                            RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
+                            config::RngSeed::Random => ChaChaRng::try_from_rng(&mut SysRng)
+                                .expect("SysRng failed while seeding TestRng"),
+                            config::RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::ChaCha(rng)
                     }
@@ -404,8 +426,9 @@ impl TestRng {
                     }
                     RngAlgorithm::Recorder => {
                         let rng =  match seed {
-                            RngSeed::Random => ChaChaRng::from_os_rng(),
-                            RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
+                            config::RngSeed::Random => ChaChaRng::try_from_rng(&mut SysRng)
+                                .expect("SysRng failed while seeding TestRng"),
+                            config::RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::Recorder {rng, record: Vec::new()}
                     },
@@ -610,7 +633,7 @@ impl TestRng {
 mod test {
     use crate::std_facade::Vec;
 
-    use rand::{Rng, RngCore};
+    use rand::{Rng, RngExt};
 
     use super::{RngAlgorithm, Seed, TestRng};
     use crate::arbitrary::any;
@@ -689,4 +712,5 @@ mod test {
         rng.fill_bytes(&mut buf[0..4]);
         assert_eq!([0, 0, 0, 0], buf);
     }
+
 }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -14,6 +14,8 @@ use core::{fmt, str, u8};
 use crate::test_runner::config;
 use rand::{Rng, RngExt, SeedableRng, TryRng};
 #[cfg(feature = "std")]
+use rand::rand_core::UnwrapErr;
+#[cfg(feature = "std")]
 use rand::rngs::SysRng;
 use rand_chacha::ChaChaRng;
 use rand_xorshift::XorShiftRng;
@@ -127,6 +129,12 @@ enum TestRngImpl {
         rng: ChaChaRng,
         record: Vec<u8>,
     },
+}
+
+#[cfg(feature = "std")]
+fn from_sys_rng<R: SeedableRng>() -> R {
+    let mut rng = UnwrapErr(SysRng);
+    R::from_rng(&mut rng)
 }
 
 impl TestRng {
@@ -407,16 +415,14 @@ impl TestRng {
                 rng: match algorithm {
                     RngAlgorithm::XorShift => {
                         let rng = match seed {
-                            config::RngSeed::Random => XorShiftRng::try_from_rng(&mut SysRng)
-                                .expect("SysRng failed while seeding TestRng"),
+                            config::RngSeed::Random => from_sys_rng::<XorShiftRng>(),
                             config::RngSeed::Fixed(seed) => XorShiftRng::seed_from_u64(seed),
                         };
                         TestRngImpl::XorShift(rng)
                     }
                     RngAlgorithm::ChaCha => {
                         let rng = match seed {
-                            config::RngSeed::Random => ChaChaRng::try_from_rng(&mut SysRng)
-                                .expect("SysRng failed while seeding TestRng"),
+                            config::RngSeed::Random => from_sys_rng::<ChaChaRng>(),
                             config::RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::ChaCha(rng)
@@ -426,8 +432,7 @@ impl TestRng {
                     }
                     RngAlgorithm::Recorder => {
                         let rng =  match seed {
-                            config::RngSeed::Random => ChaChaRng::try_from_rng(&mut SysRng)
-                                .expect("SysRng failed while seeding TestRng"),
+                            config::RngSeed::Random => from_sys_rng::<ChaChaRng>(),
                             config::RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::Recorder {rng, record: Vec::new()}

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1242,7 +1242,7 @@ mod test {
 
     #[test]
     fn new_rng_makes_separate_rng() {
-        use rand::Rng;
+        use rand::RngExt;
         let mut runner = TestRunner::default();
         let from_1 = runner.new_rng().random::<[u8; 16]>();
         let from_2 = runner.rng().random::<[u8; 16]>();
@@ -1251,7 +1251,7 @@ mod test {
 
     #[test]
     fn record_rng_use() {
-        use rand::Rng;
+        use rand::RngExt;
 
         // create value with recorder rng
         let default_config = Config::default();


### PR DESCRIPTION
## Summary

This updates `proptest` to `rand 0.10` without changing RNG behavior.

- bump the workspace rand family to `rand 0.10`, `rand_chacha 0.10`, and `rand_xorshift 0.5`
- rename the `proptest` `std` feature gate from `rand/os_rng` to `rand/sys_rng`
- port `TestRng` from `RngCore` to `TryRng`
- replace OS seeding with rand 0.10 `SysRng` seeding
- sweep the in-tree `Rng` / `RngExt` import fallout exposed by rand 0.10
- keep a deprecated `RngCore` bridge in the prelude for compatibility
- add regression tests for seeded XorShift output, seeded ChaCha output, derived child RNG output, and recorder byte capture

## Non-goals

- no README or workflow changes
- no RNG backend swaps
- no version bumps outside the rand family

## Behavior

This keeps the existing RNG model and limits the change to the rand 0.10 trait and seeding boundary.

The regression tests are there to show that seeded output, derived-child seeding, and recorder behavior stay unchanged.

## Review map

1. `Cargo.toml`, `proptest/Cargo.toml`
2. `proptest/src/test_runner/rng.rs`
3. `proptest/src/prelude.rs` and the rand import fallout sweep
4. `proptest/CHANGELOG.md`
