### PR TITLE
fix nightly ambigous SIGN_MASK and MANTISSA_MASK

### DIFF
--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -25,7 +25,9 @@ pub(crate) fn sample_uniform<X: SampleUniform>(
     start: X,
     end: X,
 ) -> X {
-    Uniform::new(start, end).expect("not uniform").sample(run.rng())
+    Uniform::new(start, end)
+        .expect("not uniform")
+        .sample(run.rng())
 }
 
 /// Generate a random value of `X`, sampled uniformly from the closed
@@ -35,27 +37,25 @@ pub fn sample_uniform_incl<X: SampleUniform>(
     start: X,
     end: X,
 ) -> X {
-    Uniform::new_inclusive(start, end).expect("not uniform").sample(run.rng())
+    Uniform::new_inclusive(start, end)
+        .expect("not uniform")
+        .sample(run.rng())
 }
 
 macro_rules! sample_uniform {
     ($name: ident, $incl:ident, $from:ty, $to:ty) => {
-        fn $name<X>(
-            run: &mut TestRunner,
-            start: $to,
-            end: $to,
-        ) -> $to {
-            Uniform::<$from>::new(start as $from, end as $from).expect("not uniform").sample(run.rng()) as $to
+        fn $name<X>(run: &mut TestRunner, start: $to, end: $to) -> $to {
+            Uniform::<$from>::new(start as $from, end as $from)
+                .expect("not uniform")
+                .sample(run.rng()) as $to
         }
 
-        fn $incl<X>(
-            run: &mut TestRunner,
-            start: $to,
-            end: $to,
-        ) -> $to {
-            Uniform::<$from>::new_inclusive(start as $from, end as $from).expect("not uniform").sample(run.rng()) as $to
-        }        
-    }
+        fn $incl<X>(run: &mut TestRunner, start: $to, end: $to) -> $to {
+            Uniform::<$from>::new_inclusive(start as $from, end as $from)
+                .expect("not uniform")
+                .sample(run.rng()) as $to
+        }
+    };
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -118,7 +118,13 @@ macro_rules! numeric_api {
         numeric_api!($typ, $typ, $epsilon);
     };
     ($typ:ident, $sample_typ:ty, $epsilon:expr) => {
-        numeric_api!($typ, $sample_typ, $epsilon, sample_uniform, sample_uniform_incl);
+        numeric_api!(
+            $typ,
+            $sample_typ,
+            $epsilon,
+            sample_uniform,
+            sample_uniform_incl
+        );
     };
     ($typ:ident, $epsilon:expr, $uniform:ident, $incl:ident) => {
         numeric_api!($typ, $typ, $epsilon, $uniform, $incl);
@@ -233,7 +239,12 @@ macro_rules! numeric_api {
 
 macro_rules! signed_integer_bin_search {
     ($typ:ident) => {
-        signed_integer_bin_search!($typ, supported_int_any, sample_uniform, sample_uniform_incl);
+        signed_integer_bin_search!(
+            $typ,
+            supported_int_any,
+            sample_uniform,
+            sample_uniform_incl
+        );
     };
     ($typ:ident, $int_any: ident, $uniform: ident, $incl: ident) => {
         #[allow(missing_docs)]
@@ -339,7 +350,12 @@ macro_rules! signed_integer_bin_search {
 
 macro_rules! unsigned_integer_bin_search {
     ($typ:ident) => {
-        unsigned_integer_bin_search!($typ, supported_int_any, sample_uniform, sample_uniform_incl);
+        unsigned_integer_bin_search!(
+            $typ,
+            supported_int_any,
+            sample_uniform,
+            sample_uniform_incl
+        );
     };
     ($typ:ident, $int_any: ident, $uniform: ident, $incl: ident) => {
         #[allow(missing_docs)]
@@ -434,13 +450,23 @@ signed_integer_bin_search!(i16);
 signed_integer_bin_search!(i32);
 signed_integer_bin_search!(i64);
 signed_integer_bin_search!(i128);
-signed_integer_bin_search!(isize, unsupported_int_any, isize_sample_uniform, isize_sample_uniform_incl);
+signed_integer_bin_search!(
+    isize,
+    unsupported_int_any,
+    isize_sample_uniform,
+    isize_sample_uniform_incl
+);
 unsigned_integer_bin_search!(u8);
 unsigned_integer_bin_search!(u16);
 unsigned_integer_bin_search!(u32);
 unsigned_integer_bin_search!(u64);
 unsigned_integer_bin_search!(u128);
-unsigned_integer_bin_search!(usize, unsupported_int_any, usize_sample_uniform, usize_sample_uniform_incl);
+unsigned_integer_bin_search!(
+    usize,
+    unsupported_int_any,
+    usize_sample_uniform,
+    usize_sample_uniform_incl
+);
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -503,7 +529,8 @@ impl FloatLayout for f16 {
     const SIGN_MASK: u16 = 0x8000;
     const EXP_MASK: u16 = 0x7c00;
     const EXP_ZERO: u16 = f16::to_bits(1.0);
-    const MANTISSA_MASK: u16 = !(Self::SIGN_MASK | Self::EXP_MASK);
+    const MANTISSA_MASK: u16 =
+        !(<Self as FloatLayout>::SIGN_MASK | Self::EXP_MASK);
 }
 
 impl FloatLayout for f32 {
@@ -704,14 +731,14 @@ macro_rules! float_any {
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 let flags = self.0.normalise();
                 let sign_mask = if flags.contains(FloatTypes::NEGATIVE) {
-                    $typ::SIGN_MASK
+                    <$typ as FloatLayout>::SIGN_MASK
                 } else {
                     0
                 };
                 let sign_or = if flags.contains(FloatTypes::POSITIVE) {
                     0
                 } else {
-                    $typ::SIGN_MASK
+                    <$typ as FloatLayout>::SIGN_MASK
                 };
 
                 macro_rules! weight {
@@ -736,19 +763,19 @@ macro_rules! float_any {
                 let (class_mask, class_or, allow_edge_exp, allow_zero_mant) =
                     prop_oneof![
                         weight!(NORMAL, 20) => Just(
-                            ($typ::EXP_MASK | $typ::MANTISSA_MASK, 0,
+                            ($typ::EXP_MASK | <$typ as FloatLayout>::MANTISSA_MASK, 0,
                              false, true)),
                         weight!(SUBNORMAL, 3) => Just(
-                            ($typ::MANTISSA_MASK, 0, true, false)),
+                            (<$typ as FloatLayout>::MANTISSA_MASK, 0, true, false)),
                         weight!(ZERO, 4) => Just(
                             (0, 0, true, true)),
                         weight!(INFINITE, 2) => Just(
                             (0, $typ::EXP_MASK, true, true)),
                         weight!(QUIET_NAN, 1) => Just(
-                            ($typ::MANTISSA_MASK >> 1, quiet_or,
+                            (<$typ as FloatLayout>::MANTISSA_MASK >> 1, quiet_or,
                              true, false)),
                         weight!(SIGNALING_NAN, 1) => Just(
-                            ($typ::MANTISSA_MASK >> 1, signaling_or,
+                            (<$typ as FloatLayout>::MANTISSA_MASK >> 1, signaling_or,
                              true, false)),
                     ].new_tree(runner)?.current();
 
@@ -762,7 +789,7 @@ macro_rules! float_any {
                     generated_value |= $typ::EXP_ZERO;
                 }
                 if !allow_zero_mant &&
-                    0 == generated_value & $typ::MANTISSA_MASK
+                    0 == generated_value & <$typ as FloatLayout>::MANTISSA_MASK
                 {
                     generated_value |= 1;
                 }
@@ -1291,9 +1318,7 @@ mod test {
     #[test]
     fn float_simplifies_to_smallest_normal() {
         let mut runner = TestRunner::default();
-        let mut value = (f64::MIN_POSITIVE..2.0)
-            .new_tree(&mut runner)
-            .unwrap();
+        let mut value = (f64::MIN_POSITIVE..2.0).new_tree(&mut runner).unwrap();
 
         while value.simplify() {}
 


### PR DESCRIPTION
switched to use a fully qualified name with these 2 associated constants to avoid ambiguity with ones from nightly `float_masks` feature