### PR TITLE
[fix] assert that rdrand is supported before making unsafe calls that expect its existence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bit-vec = "0.8.0"
 bitflags = "2.10"
 compiletest_rs = "0.11"
 convert_case = "0.11"
+core_detect = "1.0.0"
 criterion = "0.8"
 insta = "1"
 message-io = { version = "0.19.0", default-features = false, features = [

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - Fixed a panic when sampling from a single-point inclusive float range like `0.0..=0.0`. ([\#479](https://github.com/proptest-rs/proptest/issues/479))
+- [Soundness] Asserts that rdrand feature is supported by the CPU before invoking rdrand functions ([\#648](https://github.com/proptest-rs/proptest/issues/648))
 
 ### Other Notes
 

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -67,6 +67,7 @@ handle-panics = ["std"]
 
 [dependencies]
 bitflags = { workspace = true }
+core_detect = { workspace = true }
 unarray = { workspace = true }
 proptest-macro = { workspace = true, optional = true }
 num-traits = { workspace = true }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -479,23 +479,26 @@ impl TestRng {
     ))]
     pub fn hardware_rng(algorithm: RngAlgorithm) -> Self {
         use x86::random::{rdrand_slice, RdRand};
+        assert!(core_detect::is_x86_feature_detected!("rdrand"));
 
         Self::from_seed_internal(match algorithm {
             RngAlgorithm::XorShift => {
                 // Initialize to a sane seed just in case
                 let mut seed: [u8; 16] = TestRng::SEED_FOR_XOR_SHIFT;
+                // SAFETY: rdrand feature is asserted to be detected at the beginning of the function
                 unsafe {
                     let r = rdrand_slice(&mut seed);
-                    debug_assert!(r, "hardware_rng should only be called on machines with support for rdrand");
+                    assert!(r, "hardware_rng should only be called on machines with support for rdrand");
                 }
                 Seed::XorShift(seed)
             }
             RngAlgorithm::ChaCha => {
                 // Initialize to a sane seed just in case
                 let mut seed: [u8; 32] = TestRng::SEED_FOR_CHA_CHA;
+                // SAFETY: rdrand feature is asserted to be detected at the beginning of the function
                 unsafe {
                     let r = rdrand_slice(&mut seed);
-                    debug_assert!(r, "hardware_rng should only be called on machines with support for rdrand");
+                    assert!(r, "hardware_rng should only be called on machines with support for rdrand");
                 }
                 Seed::ChaCha(seed)
             }
@@ -505,9 +508,10 @@ impl TestRng {
             RngAlgorithm::Recorder => {
                 // Initialize to a sane seed just in case
                 let mut seed: [u8; 32] = TestRng::SEED_FOR_CHA_CHA;
+                // SAFETY: rdrand feature is asserted to be detected at the beginning of the function
                 unsafe {
                     let r = rdrand_slice(&mut seed);
-                    debug_assert!(r, "hardware_rng should only be called on machines with support for rdrand");
+                    assert!(r, "hardware_rng should only be called on machines with support for rdrand");
                 }
                 Seed::Recorder(seed)
             }


### PR DESCRIPTION
fixes #651 